### PR TITLE
release Codex Bridge minor update

### DIFF
--- a/.changeset/honest-codex-bridge.md
+++ b/.changeset/honest-codex-bridge.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": minor
+---
+
+Identify requests as Codex Bridge, require OAuth callback state validation, clarify CLI credential import, and update the extension's visible product name.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Codex Bridge Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "npm: compile"
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for helping improve OpenAI Codex for GitHub Copilot Chat.
+Thanks for helping improve Codex Bridge for Copilot Chat.
 
 ## Before opening work
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://raw.githubusercontent.com/grikomsn/openai-oauth-copilot-chat/main/assets/cover.jpg" alt="OpenAI Codex and GitHub Copilot" width="960">
 </p>
 
-<h1 align="center">OpenAI Codex for GitHub Copilot Chat</h1>
+<h1 align="center">Codex Bridge for Copilot Chat</h1>
 
 <p align="center">Use OpenAI Codex models directly from the GitHub Copilot Chat model picker in Visual Studio Code with your ChatGPT Plus or Pro subscription.</p>
 
@@ -34,10 +34,10 @@ This extension is a native VS Code `LanguageModelChatProvider`. It handles OpenA
 
 ## Quick start
 
-1. Install [OpenAI Codex for GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=grikomsn.openai-oauth-copilot-chat). You need VS Code 1.125 or newer, GitHub Copilot Chat, and a ChatGPT account with Codex access.
-2. Run **OpenAI Codex: Manage Connection** from the Command Palette.
+1. Install [Codex Bridge for Copilot Chat](https://marketplace.visualstudio.com/items?itemName=grikomsn.openai-oauth-copilot-chat). You need VS Code 1.125 or newer, GitHub Copilot Chat, and a ChatGPT account with Codex access.
+2. Run **Codex Bridge: Manage Connection** from the Command Palette.
 3. Choose **Sign in with ChatGPT** and complete the browser flow.
-4. In Copilot Chat, open the model picker, choose **Manage Models**, enable **OpenAI Codex**, and select a Codex model.
+4. In Copilot Chat, open the model picker, choose **Manage Models**, enable **Codex Bridge**, and select a Codex model.
 
 Models contributed by this extension include an **(OAuth)** suffix so they remain distinguishable from models contributed by other installed OpenAI extensions.
 
@@ -45,15 +45,15 @@ If another process uses local port `1455`, choose **Sign in manually**. If the C
 
 ## Commands
 
-| Command                                | Purpose                                                      |
-| -------------------------------------- | ------------------------------------------------------------ |
-| OpenAI Codex: Manage Connection        | Sign in, test, inspect logs, or sign out                     |
-| OpenAI Codex: Sign In with ChatGPT     | Start the local browser OAuth flow                           |
-| OpenAI Codex: Sign In Manually         | Paste a callback URL when port 1455 is unavailable           |
-| OpenAI Codex: Import Codex CLI Session | Import an existing local Codex CLI login                     |
-| OpenAI Codex: Test Connection          | Send a small live request to the Codex backend               |
-| OpenAI Codex: Show Usage               | Refresh and inspect subscription quota plus inference tokens |
-| OpenAI Codex: Show Diagnostics         | Show session presence and registered models without secrets  |
+| Command                                                   | Purpose                                                      |
+| --------------------------------------------------------- | ------------------------------------------------------------ |
+| Codex Bridge: Manage Connection                           | Sign in, test, inspect logs, or sign out                     |
+| Codex Bridge: Sign In with ChatGPT                        | Start the local browser OAuth flow                           |
+| Codex Bridge: Sign In Manually                            | Paste a callback URL when port 1455 is unavailable           |
+| Codex Bridge: Import Codex CLI Session (Advanced)         | Copy an existing local Codex CLI login after a warning       |
+| Codex Bridge: Test Connection                             | Send a small live request to the Codex backend               |
+| Codex Bridge: Show Usage                                  | Refresh and inspect subscription quota plus inference tokens |
+| Codex Bridge: Show Diagnostics                            | Show session presence and registered models without secrets  |
 
 ## Settings
 
@@ -77,5 +77,7 @@ The status bar reads the same ChatGPT Codex quota endpoint used by Codex CLI and
 ## Privacy and status
 
 OAuth tokens are stored through VS Code Secret Storage and are sent only to OpenAI authentication and ChatGPT Codex endpoints. This is an independent community extension, not an official OpenAI or GitHub product. The ChatGPT Codex backend is not a public compatibility API and can change; see [docs/security.md](docs/security.md).
+
+Requests identify this extension as `openai-oauth-copilot-chat`; they do not claim to originate from the official Codex CLI or VS Code extension. The shared OAuth client and ChatGPT backend are undocumented integration surfaces, so OpenAI may change or revoke compatibility without notice.
 
 Unofficial project; not affiliated with OpenAI, GitHub, or Microsoft. The ChatGPT Codex backend is not a public compatibility API and can change. Licensed under [MIT](LICENSE).

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,6 +10,8 @@ The extension has three small layers:
 
 The ChatGPT Codex endpoint requires a bearer token plus the ChatGPT account ID extracted from OAuth JWT claims. Requests use `store: false` and send full conversation history.
 
+Shared protocol constants live in `protocol.ts`. OAuth and inference requests must use the extension originator and user agent defined there; do not identify requests as the official Codex CLI or OpenAI VS Code extension. The OAuth client and ChatGPT backend are undocumented integration surfaces and may change without notice.
+
 ## Local workflow
 
 ```sh
@@ -19,7 +21,7 @@ npm run watch
 npm run package
 ```
 
-For local debugging, open this folder in VS Code and press F5 to launch an Extension Development Host. Authentication and live connection testing must be performed in that host.
+For local debugging, open this folder in VS Code and run **Run Codex Bridge Extension** from the Run and Debug view (or press F5) to launch an Extension Development Host. Authentication and live connection testing must be performed in that host.
 
 Install a local build with:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,16 +5,21 @@
 - OAuth access and refresh tokens are stored with VS Code Secret Storage.
 - Tokens and prompts are never written to the output channel.
 - Diagnostics report only whether a session exists, the account email when present, and public model metadata.
-- Codex CLI import reads only `~/.codex/auth.json` after the user explicitly runs the import command.
+- Codex CLI import reads only `~/.codex/auth.json` after the user explicitly runs the advanced import command and confirms the credential-copy warning.
 
 ## Network destinations
 
 - `https://auth.openai.com/oauth/authorize`
 - `https://auth.openai.com/oauth/token`
 - `https://chatgpt.com/backend-api/codex/responses`
+- `https://chatgpt.com/backend-api/wham/usage`
+
+Requests use the independent originator `openai-oauth-copilot-chat` and a matching user agent. They do not identify as the official Codex CLI or OpenAI VS Code extension.
 
 ## Reporting vulnerabilities
 
 Do not include tokens, callback URLs, prompts, or account IDs in a public issue. Use GitHub's private security advisory flow for the repository.
 
 This project is independent and is not endorsed by OpenAI, GitHub, or Microsoft. Users are responsible for complying with the terms that apply to their accounts.
+
+The shared OAuth client and ChatGPT Codex backend are undocumented integration surfaces. Compatibility may change or be revoked without notice.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,7 +4,7 @@
 
 Run `code --install-extension openai-oauth-copilot-chat-0.1.0.vsix`, then reload VS Code.
 
-Use **OpenAI Codex: Manage Connection** to authenticate. After sign-in, open Copilot Chat's model picker and enable a model under **Manage Models → OpenAI Codex**.
+Use **Codex Bridge: Manage Connection** to authenticate. After sign-in, open Copilot Chat's model picker and enable a model under **Manage Models → Codex Bridge**.
 
 Supported models expose a combined **Speed & Effort** menu with choices such as **Normal · Medium** and **Fast · High**. Normal mode uses standard processing. Fast mode requests roughly 1.5× generation speed with increased account usage. The picker selection applies to that request and overrides the two independent workspace defaults.
 
@@ -12,16 +12,18 @@ After sign-in, the **Codex** status-bar item shows ChatGPT subscription utilizat
 
 ## Browser callback problems
 
-OpenAI's Codex OAuth client redirects to `http://localhost:1455/auth/callback`. The normal flow temporarily listens on that port. If it is busy, use **OpenAI Codex: Sign In Manually**, finish authentication, and paste the callback URL shown in the browser address bar.
+OpenAI's Codex OAuth client redirects to `http://localhost:1455/auth/callback`. The normal flow temporarily listens on that port. If it is busy, use **Codex Bridge: Sign In Manually**, finish authentication, and paste the complete callback URL shown in the browser address bar. Manual callbacks must include both the authorization code and matching OAuth state.
+
+**Codex Bridge: Import Codex CLI Session (Advanced)** copies the CLI's OAuth access and refresh credentials into VS Code Secret Storage. Prefer a fresh ChatGPT sign-in. Import only when you trust the extension and intentionally want both clients to use credentials derived from the same CLI session.
 
 ## Models do not appear
 
 - Confirm VS Code is version 1.125 or newer.
 - Confirm GitHub Copilot Chat is installed and enabled.
-- Run **OpenAI Codex: Show Diagnostics** and check that the provider reports registered models.
-- Open the model picker, choose **Manage Models**, and enable OpenAI Codex models.
+- Run **Codex Bridge: Show Diagnostics** and check that the provider reports registered models.
+- Open the model picker, choose **Manage Models**, and enable Codex Bridge models.
 - Your organization can disable bring-your-own-model providers through GitHub Copilot policy.
 
 ## Requests fail
 
-Run **OpenAI Codex: Test Connection**, then inspect **Output → OpenAI Codex**. A `401` triggers one automatic token refresh. A `403` generally means the signed-in account cannot access the selected model. A `429` indicates account capacity or rate limits.
+Run **Codex Bridge: Test Connection**, then inspect **Output → Codex Bridge**. A `401` triggers one automatic token refresh. A `403` generally means the signed-in account cannot access the selected model. A `429` indicates account capacity or rate limits.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-oauth-copilot-chat",
-  "displayName": "OpenAI Codex for GitHub Copilot Chat",
+  "displayName": "Codex Bridge for Copilot Chat",
   "description": "Use OpenAI Codex models in GitHub Copilot Chat with your ChatGPT Plus or Pro subscription.",
   "version": "0.3.1",
   "publisher": "grikomsn",
@@ -39,35 +39,35 @@
     "commands": [
       {
         "command": "openaiCodex.manage",
-        "title": "OpenAI Codex: Manage Connection"
+        "title": "Codex Bridge: Manage Connection"
       },
       {
         "command": "openaiCodex.signIn",
-        "title": "OpenAI Codex: Sign In with ChatGPT"
+        "title": "Codex Bridge: Sign In with ChatGPT"
       },
       {
         "command": "openaiCodex.signInManual",
-        "title": "OpenAI Codex: Sign In Manually"
+        "title": "Codex Bridge: Sign In Manually"
       },
       {
         "command": "openaiCodex.importCodexSession",
-        "title": "OpenAI Codex: Import Codex CLI Session"
+        "title": "Codex Bridge: Import Codex CLI Session (Advanced)"
       },
       {
         "command": "openaiCodex.testConnection",
-        "title": "OpenAI Codex: Test Connection"
+        "title": "Codex Bridge: Test Connection"
       },
       {
         "command": "openaiCodex.showUsage",
-        "title": "OpenAI Codex: Show Usage"
+        "title": "Codex Bridge: Show Usage"
       },
       {
         "command": "openaiCodex.diagnostics",
-        "title": "OpenAI Codex: Show Diagnostics"
+        "title": "Codex Bridge: Show Diagnostics"
       }
     ],
     "configuration": {
-      "title": "OpenAI Codex for Copilot Chat",
+      "title": "Codex Bridge for Copilot Chat",
       "properties": {
         "openaiCodex.reasoningEffort": {
           "type": "string",
@@ -116,7 +116,7 @@
     "languageModelChatProviders": [
       {
         "vendor": "openai-codex",
-        "displayName": "OpenAI Codex",
+        "displayName": "Codex Bridge",
         "managementCommand": "openaiCodex.manage"
       }
     ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { messageOf } from "./errors";
 import { OpenAIOAuth, type AuthorizationFlow } from "./oauth";
 import { OpenAICodexProvider } from "./provider";
+import { EXTENSION_DISPLAY_NAME, extensionUserAgent } from "./protocol";
 import {
   formatUsageRows,
   formatUsageStatusBar,
@@ -13,17 +14,17 @@ import {
 const USAGE_STATE_KEY = "openaiCodex.usageSnapshot.v1";
 
 export function activate(context: vscode.ExtensionContext): void {
-  const output = vscode.window.createOutputChannel("OpenAI Codex");
+  const output = vscode.window.createOutputChannel("Codex Bridge");
   const oauth = new OpenAIOAuth(context.secrets);
   const version = context.extension.packageJSON.version as string;
   const provider = new OpenAICodexProvider(
     oauth,
     output,
-    `codex_vscode/${version} VSCode/${vscode.version}`,
+    extensionUserAgent(version, vscode.version),
     context.globalState.get<CodexUsageSnapshot>(USAGE_STATE_KEY) ?? {},
   );
   const usageStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 91);
-  usageStatus.name = "OpenAI Codex usage";
+  usageStatus.name = "Codex Bridge usage";
   usageStatus.command = "openaiCodex.showUsage";
   renderUsageStatus(usageStatus, provider.getUsageSnapshot());
   context.subscriptions.push(
@@ -49,7 +50,7 @@ export function activate(context: vscode.ExtensionContext): void {
       if (event.affectsConfiguration("openaiCodex.showUsageStatusBar")) updateUsageStatusVisibility(usageStatus);
     }),
   );
-  output.appendLine(`[activate] OpenAI Codex for Copilot Chat ${version} on VS Code ${vscode.version}`);
+  output.appendLine(`[activate] ${EXTENSION_DISPLAY_NAME} ${version} on VS Code ${vscode.version}`);
   void oauth.hasSession().then((signedIn) => {
     if (!signedIn) return;
     updateUsageStatusVisibility(usageStatus);
@@ -65,16 +66,16 @@ async function manage(
 ): Promise<void> {
   const session = await oauth.sessionInfo();
   const picked = await vscode.window.showQuickPick(session ? [
-    { label: "$(pulse) Show OpenAI Codex usage", action: "usage" },
-    { label: "$(check) Test OpenAI Codex connection", action: "test" },
-    { label: "$(output) Show OpenAI Codex logs", action: "logs" },
-    { label: "$(sign-out) Sign out of OpenAI Codex", action: "signout" },
+    { label: "$(pulse) Show Codex usage", action: "usage" },
+    { label: "$(check) Test Codex connection", action: "test" },
+    { label: "$(output) Show Codex Bridge logs", action: "logs" },
+    { label: "$(sign-out) Sign out of Codex Bridge", action: "signout" },
   ] : [
     { label: "$(globe) Sign in with ChatGPT", action: "signin", description: "ChatGPT Plus or Pro" },
     { label: "$(link) Sign in manually", action: "manual", description: "Use if localhost:1455 is unavailable" },
-    { label: "$(terminal) Import Codex CLI session", action: "import", description: "Read ~/.codex/auth.json" },
-    { label: "$(output) Show OpenAI Codex logs", action: "logs" },
-  ], { title: `OpenAI Codex — ${session?.email ?? (session ? "signed in" : "not signed in")}` });
+    { label: "$(terminal) Import Codex CLI session (Advanced)", action: "import", description: "Copies OAuth credentials from ~/.codex/auth.json" },
+    { label: "$(output) Show Codex Bridge logs", action: "logs" },
+  ], { title: `Codex Bridge — ${session?.email ?? (session ? "signed in" : "not signed in")}` });
   if (!picked) return;
   if (picked.action === "signin") await browserSignIn(oauth, provider, output);
   else if (picked.action === "manual") await manualSignIn(oauth, provider, output);
@@ -87,7 +88,7 @@ async function manage(
     provider.clearUsage();
     usageStatus.hide();
     provider.fireDidChange();
-    vscode.window.showInformationMessage("Signed out of OpenAI Codex.");
+    vscode.window.showInformationMessage("Signed out of Codex Bridge.");
   }
 }
 
@@ -105,10 +106,10 @@ async function browserSignIn(oauth: OpenAIOAuth, provider: OpenAICodexProvider, 
     );
     provider.fireDidChange();
     void provider.refreshUsage().catch((error) => output.appendLine(`[usage] post-sign-in refresh failed: ${messageOf(error)}`));
-    vscode.window.showInformationMessage("Signed in to OpenAI Codex with ChatGPT.");
+    vscode.window.showInformationMessage("Signed in to Codex Bridge with ChatGPT.");
   } catch (error) {
     attempt?.cancel();
-    showError("OpenAI sign-in failed", error, output);
+    showError("ChatGPT sign-in failed", error, output);
   }
 }
 
@@ -118,22 +119,28 @@ async function manualSignIn(oauth: OpenAIOAuth, provider: OpenAICodexProvider, o
     await vscode.env.clipboard.writeText(flow.url);
     await vscode.env.openExternal(vscode.Uri.parse(flow.url));
     const callback = await vscode.window.showInputBox({
-      title: "OpenAI Codex manual sign-in",
-      prompt: "After signing in, paste the full localhost callback URL (or its code and state query string)",
+      title: "Codex Bridge manual sign-in",
+      prompt: "After signing in, paste the full localhost callback URL (or a query string containing both code and state)",
       ignoreFocusOut: true,
     });
     if (!callback) return;
     await oauth.completeAuthorization(callback, flow);
     provider.fireDidChange();
     void provider.refreshUsage().catch((error) => output.appendLine(`[usage] post-sign-in refresh failed: ${messageOf(error)}`));
-    vscode.window.showInformationMessage("Signed in to OpenAI Codex with ChatGPT.");
+    vscode.window.showInformationMessage("Signed in to Codex Bridge with ChatGPT.");
   } catch (error) {
-    showError("OpenAI manual sign-in failed", error, output);
+    showError("ChatGPT manual sign-in failed", error, output);
   }
 }
 
 async function importCodexSession(oauth: OpenAIOAuth, provider: OpenAICodexProvider, output: vscode.OutputChannel): Promise<void> {
   try {
+    const confirmed = await vscode.window.showWarningMessage(
+      "Importing a Codex CLI session copies its OAuth access and refresh credentials into VS Code Secret Storage. A fresh ChatGPT sign-in is recommended.",
+      { modal: true, detail: "Continue only if you trust this extension and want both clients to use credentials derived from the same CLI session." },
+      "Import session",
+    );
+    if (confirmed !== "Import session") return;
     const session = await oauth.importCodexCliSession();
     provider.fireDidChange();
     void provider.refreshUsage().catch((error) => output.appendLine(`[usage] post-import refresh failed: ${messageOf(error)}`));
@@ -146,13 +153,13 @@ async function importCodexSession(oauth: OpenAIOAuth, provider: OpenAICodexProvi
 async function testConnection(provider: OpenAICodexProvider, output: vscode.OutputChannel): Promise<void> {
   try {
     const result = await vscode.window.withProgress(
-      { location: vscode.ProgressLocation.Notification, title: "Testing OpenAI Codex…" },
+      { location: vscode.ProgressLocation.Notification, title: "Testing Codex connection…" },
       () => provider.testConnection(),
     );
     output.appendLine(`[test] model=${result.model} speed=${result.speedMode} effort=${result.reasoningEffort} response=${result.text}`);
-    vscode.window.showInformationMessage(`OpenAI Codex verified with ${result.model} (${result.speedMode}, ${result.reasoningEffort}): ${result.text}`);
+    vscode.window.showInformationMessage(`Codex connection verified with ${result.model} (${result.speedMode}, ${result.reasoningEffort}): ${result.text}`);
   } catch (error) {
-    showError("OpenAI Codex connection test failed", error, output);
+    showError("Codex connection test failed", error, output);
   }
 }
 
@@ -160,7 +167,7 @@ async function showUsage(provider: OpenAICodexProvider, output: vscode.OutputCha
   let snapshot = provider.getUsageSnapshot();
   try {
     snapshot = await vscode.window.withProgress(
-      { location: vscode.ProgressLocation.Window, title: "Refreshing OpenAI Codex usage…" },
+      { location: vscode.ProgressLocation.Window, title: "Refreshing Codex usage…" },
       () => provider.refreshUsage(),
     );
   } catch (error) {
@@ -173,8 +180,8 @@ async function showUsage(provider: OpenAICodexProvider, output: vscode.OutputCha
     { label: "$(link-external) Open ChatGPT Codex", action: "open", alwaysShow: true },
   ], {
     title: snapshot.updatedAt
-      ? `OpenAI Codex usage — updated ${new Date(snapshot.updatedAt).toLocaleTimeString()}`
-      : "OpenAI Codex usage",
+      ? `Codex usage — updated ${new Date(snapshot.updatedAt).toLocaleTimeString()}`
+      : "Codex usage",
     placeHolder: "Subscription quota and locally tracked inference tokens",
     matchOnDescription: true,
     matchOnDetail: true,
@@ -213,7 +220,7 @@ async function diagnostics(oauth: OpenAIOAuth, output: vscode.OutputChannel): Pr
   const models = await vscode.lm.selectChatModels({ vendor: "openai-codex" });
   const session = await oauth.sessionInfo();
   const content = [
-    "# OpenAI Codex for Copilot Chat diagnostics", "",
+    `# ${EXTENSION_DISPLAY_NAME} diagnostics`, "",
     `- VS Code: ${vscode.version}`,
     `- OAuth session: ${session ? "present" : "missing"}`,
     `- Account: ${session?.email ?? "unknown"}`,

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { decodeJwt, parseCallback } from "./oauth";
+import type * as vscode from "vscode";
+import { decodeJwt, OpenAIOAuth, parseCallback } from "./oauth";
+import { OAUTH_ORIGINATOR } from "./protocol";
 
 test("parses OAuth callback URLs", () => {
   assert.deepEqual(parseCallback("http://localhost:1455/auth/callback?code=abc&state=xyz"), {
@@ -11,4 +13,31 @@ test("parses OAuth callback URLs", () => {
 test("decodes JWT payloads", () => {
   const payload = Buffer.from(JSON.stringify({ email: "dev@example.com" })).toString("base64url");
   assert.deepEqual(decodeJwt(`header.${payload}.signature`), { email: "dev@example.com" });
+});
+
+test("identifies the extension as the OAuth originator", () => {
+  const oauth = new OpenAIOAuth({} as vscode.SecretStorage);
+  const authorization = new URL(oauth.createAuthorizationFlow().url);
+  assert.equal(authorization.searchParams.get("originator"), OAUTH_ORIGINATOR);
+  assert.notEqual(authorization.searchParams.get("originator"), "codex_cli_rs");
+});
+
+test("rejects OAuth callbacks with missing or mismatched state before token exchange", async () => {
+  let fetchCalls = 0;
+  const fetcher = (async () => {
+    fetchCalls += 1;
+    return new Response(null, { status: 500 });
+  }) as typeof fetch;
+  const oauth = new OpenAIOAuth({} as vscode.SecretStorage, fetcher);
+  const flow = { url: "https://auth.openai.com", state: "expected-state", verifier: "verifier" };
+
+  await assert.rejects(
+    oauth.completeAuthorization("http://localhost:1455/auth/callback?code=abc", flow),
+    /Invalid OpenAI OAuth callback state/,
+  );
+  await assert.rejects(
+    oauth.completeAuthorization("http://localhost:1455/auth/callback?code=abc&state=wrong-state", flow),
+    /Invalid OpenAI OAuth callback state/,
+  );
+  assert.equal(fetchCalls, 0);
 });

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -5,11 +5,15 @@ import { join } from "node:path";
 import { readFile } from "node:fs/promises";
 import type * as vscode from "vscode";
 import { responseError } from "./errors";
+import {
+  EXTENSION_DISPLAY_NAME,
+  OAUTH_ORIGINATOR,
+  OPENAI_AUTHORIZE_URL,
+  OPENAI_OAUTH_CLIENT_ID,
+  OPENAI_REDIRECT_URI,
+  OPENAI_TOKEN_URL,
+} from "./protocol";
 
-export const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
-export const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
-export const TOKEN_URL = "https://auth.openai.com/oauth/token";
-export const REDIRECT_URI = "http://localhost:1455/auth/callback";
 const CALLBACK_PORT = 1455;
 const CALLBACK_PATH = "/auth/callback";
 const SCOPE = "openid email profile offline_access";
@@ -63,10 +67,10 @@ export class OpenAIOAuth {
     const verifier = randomBytes(96).toString("base64url");
     const challenge = createHash("sha256").update(verifier).digest("base64url");
     const state = randomBytes(32).toString("base64url");
-    const url = new URL(AUTHORIZE_URL);
+    const url = new URL(OPENAI_AUTHORIZE_URL);
     url.searchParams.set("response_type", "code");
-    url.searchParams.set("client_id", CLIENT_ID);
-    url.searchParams.set("redirect_uri", REDIRECT_URI);
+    url.searchParams.set("client_id", OPENAI_OAUTH_CLIENT_ID);
+    url.searchParams.set("redirect_uri", OPENAI_REDIRECT_URI);
     url.searchParams.set("scope", SCOPE);
     url.searchParams.set("code_challenge", challenge);
     url.searchParams.set("code_challenge_method", "S256");
@@ -74,7 +78,7 @@ export class OpenAIOAuth {
     url.searchParams.set("prompt", "login");
     url.searchParams.set("id_token_add_organizations", "true");
     url.searchParams.set("codex_cli_simplified_flow", "true");
-    url.searchParams.set("originator", "codex_cli_rs");
+    url.searchParams.set("originator", OAUTH_ORIGINATOR);
     return { url: url.toString(), state, verifier };
   }
 
@@ -93,7 +97,7 @@ export class OpenAIOAuth {
     const completion = new Promise<OAuthSession>((resolve, reject) => {
       rejectCompletion = reject;
       server = createServer(async (request, response) => {
-        const callback = new URL(request.url ?? "/", REDIRECT_URI);
+        const callback = new URL(request.url ?? "/", OPENAI_REDIRECT_URI);
         if (callback.pathname !== CALLBACK_PATH) {
           response.writeHead(404).end("Not found");
           return;
@@ -106,14 +110,14 @@ export class OpenAIOAuth {
           const session = await this.completeAuthorization(callback.toString(), flow);
           settled = true;
           response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-          response.end(callbackPage("Signed in to OpenAI Codex", "You can close this tab and return to Visual Studio Code."));
+          response.end(callbackPage(`Signed in to ${EXTENSION_DISPLAY_NAME}`, "You can close this tab and return to Visual Studio Code."));
           close();
           resolve(session);
         } catch (error) {
           settled = true;
           const message = error instanceof Error ? error.message : String(error);
           response.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
-          response.end(callbackPage("OpenAI sign-in failed", message));
+          response.end(callbackPage("ChatGPT sign-in failed", message));
           close();
           reject(error);
         }
@@ -121,7 +125,7 @@ export class OpenAIOAuth {
       server.once("error", (error) => {
         settled = true;
         close();
-        reject(new Error(`Unable to listen on ${REDIRECT_URI}: ${error.message}. Use “OpenAI Codex: Sign In Manually” instead.`));
+        reject(new Error(`Unable to listen on ${OPENAI_REDIRECT_URI}: ${error.message}. Use “Codex Bridge: Sign In Manually” instead.`));
       });
       server.listen(CALLBACK_PORT, "127.0.0.1");
       timeout = setTimeout(() => {
@@ -147,15 +151,15 @@ export class OpenAIOAuth {
     const callback = parseCallback(callbackInput);
     if (callback.error) throw new Error(callback.errorDescription ?? callback.error);
     if (!callback.code) throw new Error("The callback does not contain an authorization code");
-    if (callback.state && callback.state !== flow.state) throw new Error("Invalid OpenAI OAuth callback state");
-    const response = await this.fetcher(TOKEN_URL, {
+    if (callback.state !== flow.state) throw new Error("Invalid OpenAI OAuth callback state");
+    const response = await this.fetcher(OPENAI_TOKEN_URL, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
       body: new URLSearchParams({
         grant_type: "authorization_code",
-        client_id: CLIENT_ID,
+        client_id: OPENAI_OAUTH_CLIENT_ID,
         code: callback.code,
-        redirect_uri: REDIRECT_URI,
+        redirect_uri: OPENAI_REDIRECT_URI,
         code_verifier: flow.verifier,
       }),
     });
@@ -195,14 +199,13 @@ export class OpenAIOAuth {
   private async refresh(session: OAuthSession): Promise<OAuthSession> {
     if (!this.refreshPromise) {
       this.refreshPromise = (async () => {
-        const response = await this.fetcher(TOKEN_URL, {
+        const response = await this.fetcher(OPENAI_TOKEN_URL, {
           method: "POST",
           headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
           body: new URLSearchParams({
             grant_type: "refresh_token",
-            client_id: CLIENT_ID,
+            client_id: OPENAI_OAUTH_CLIENT_ID,
             refresh_token: session.refreshToken,
-            scope: "openid profile email",
           }),
         });
         if (!response.ok) throw await responseError("OpenAI token refresh failed", response);

--- a/src/protocol.test.ts
+++ b/src/protocol.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  EXTENSION_DISPLAY_NAME,
+  EXTENSION_PRODUCT_ID,
+  OAUTH_ORIGINATOR,
+  extensionUserAgent,
+} from "./protocol";
+
+test("uses a consistent independent extension identity", () => {
+  assert.equal(EXTENSION_DISPLAY_NAME, "Codex Bridge for Copilot Chat");
+  assert.equal(OAUTH_ORIGINATOR, EXTENSION_PRODUCT_ID);
+  assert.equal(extensionUserAgent("1.2.3", "1.125.0"), "openai-oauth-copilot-chat/1.2.3 VSCode/1.125.0");
+  assert.doesNotMatch(extensionUserAgent("1.2.3", "1.125.0"), /codex_(?:cli|vscode)/);
+});

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,0 +1,14 @@
+export const EXTENSION_DISPLAY_NAME = "Codex Bridge for Copilot Chat";
+export const EXTENSION_PRODUCT_ID = "openai-oauth-copilot-chat";
+export const OAUTH_ORIGINATOR = EXTENSION_PRODUCT_ID;
+
+export const OPENAI_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+export const OPENAI_AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
+export const OPENAI_TOKEN_URL = "https://auth.openai.com/oauth/token";
+export const OPENAI_REDIRECT_URI = "http://localhost:1455/auth/callback";
+export const CHATGPT_CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
+export const CHATGPT_CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+
+export function extensionUserAgent(version: string, vscodeVersion: string): string {
+  return `${EXTENSION_PRODUCT_ID}/${version} VSCode/${vscodeVersion}`;
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,6 +8,11 @@ import {
   type ModelRequestOptions,
 } from "./model-options";
 import { OpenAIOAuth } from "./oauth";
+import {
+  CHATGPT_CODEX_RESPONSES_URL,
+  CHATGPT_CODEX_USAGE_URL,
+  OAUTH_ORIGINATOR,
+} from "./protocol";
 import { ResponsesStreamParser, type CodexStreamEvent } from "./sse";
 import {
   mergeQuotaPayload,
@@ -16,8 +21,6 @@ import {
   type CodexUsageSnapshot,
 } from "./usage";
 
-const RESPONSES_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
-const USAGE_ENDPOINT = "https://chatgpt.com/backend-api/wham/usage";
 const DEFAULT_INSTRUCTIONS = "You are OpenAI Codex, a coding agent in Visual Studio Code. Be concise, correct, and use the supplied tools when useful.";
 const MODELS: ReadonlyArray<{ id: string; input: number; output: number; image?: boolean }> = [
   { id: "gpt-5.6-sol", input: 372_000, output: 128_000, image: true },
@@ -171,7 +174,7 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
   }
 
   private async sendUsageRequest(credentials: { token: string; accountId?: string }): Promise<Response> {
-    return fetch(USAGE_ENDPOINT, {
+    return fetch(CHATGPT_CODEX_USAGE_URL, {
       headers: {
         Authorization: `Bearer ${credentials.token}`,
         Accept: "application/json",
@@ -205,14 +208,14 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     const listener = cancellation.onCancellationRequested(() => controller.abort());
     const sessionId = randomUUID();
     try {
-      return await fetch(RESPONSES_ENDPOINT, {
+      return await fetch(CHATGPT_CODEX_RESPONSES_URL, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${credentials.token}`,
           "Content-Type": "application/json",
           Accept: "text/event-stream",
           "User-Agent": this.userAgent,
-          Originator: "codex_cli_rs",
+          Originator: OAUTH_ORIGINATOR,
           Session_id: sessionId,
           Conversation_id: sessionId,
           ...(credentials.accountId ? { "Chatgpt-Account-Id": credentials.accountId } : {}),

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -145,7 +145,7 @@ export function formatUsageStatusBar(snapshot: CodexUsageSnapshot): string {
 }
 
 export function formatUsageTooltip(snapshot: CodexUsageSnapshot, now = Date.now()): string {
-  const lines = [`OpenAI Codex usage${snapshot.planType ? ` (${snapshot.planType})` : ""}`];
+  const lines = [`Codex Bridge usage${snapshot.planType ? ` (${snapshot.planType})` : ""}`];
   if (snapshot.primary) lines.push(windowSummary(snapshot.primary, now));
   if (snapshot.secondary) lines.push(windowSummary(snapshot.secondary, now));
   if (snapshot.lastRequest) lines.push(`Last request: ${requestSummary(snapshot.lastRequest)}`);


### PR DESCRIPTION
## What changed

- rename the visible extension to **Codex Bridge for Copilot Chat** while preserving the existing image assets
- identify OAuth and inference requests as `openai-oauth-copilot-chat` instead of official Codex clients
- require exact OAuth callback state validation and omit refresh scopes
- centralize protocol identity and endpoints
- add an explicit advanced warning before importing Codex CLI credentials
- update documentation, tests, and the VS Code development launch configuration
- add a minor Changeset targeting version `0.4.0`

## Why

The provider previously identified requests as official Codex CLI/VS Code clients and accepted callbacks without a state value. This release gives the community extension an independent identity, closes the callback-state gap, and makes credential copying explicit.

## User impact

The Marketplace and command-palette name changes to **Codex Bridge for Copilot Chat**. Existing command IDs, settings, secrets, provider IDs, and image assets remain compatible.

## Verification

- `npm run check` — 19 tests pass
- `npm run package` — VSIX packages successfully
- VS Code Extension Development Host — all commands registered under Codex Bridge
- diagnostics — nine models registered
- live connection test — successful with `gpt-5.6-sol`
- image assets verified unchanged