### PR TITLE
chore: version extension 0.4.0

### DIFF
--- a/.changeset/honest-codex-bridge.md
+++ b/.changeset/honest-codex-bridge.md
@@ -1,5 +1,0 @@
----
-"openai-oauth-copilot-chat": minor
----
-
-Identify requests as Codex Bridge, require OAuth callback state validation, clarify CLI credential import, and update the extension's visible product name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0
+
+### Minor Changes
+
+- d936863: Identify requests as Codex Bridge, require OAuth callback state validation, clarify CLI credential import, and update the extension's visible product name.
+
 ## 0.3.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openai-oauth-copilot-chat",
   "displayName": "Codex Bridge for Copilot Chat",
   "description": "Use OpenAI Codex models in GitHub Copilot Chat with your ChatGPT Plus or Pro subscription.",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "publisher": "grikomsn",
   "license": "MIT",
   "icon": "assets/icon.png",


### PR DESCRIPTION
## Summary

- bump the extension from 0.3.1 to 0.4.0
- add the generated 0.4.0 changelog entry
- consume the minor Changeset

This PR was generated manually with `npx changeset version` because repository settings currently prevent GitHub Actions from creating pull requests.

## Verification

- `npm run check` — 19 tests passed
- `npm run package` — produced `openai-oauth-copilot-chat-0.4.0.vsix`