### PR TITLE
docs: tidy source references and JSDoc

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,22 @@ The extension has three small layers:
 - `provider.ts` translates VS Code language-model messages and tools into stateless OpenAI Responses input items.
 - `sse.ts` incrementally parses Responses API events into VS Code text, thinking, usage, and tool-call parts.
 
+Each implementation stays beside its focused `node:test` coverage in `src/`:
+
+| Area | Implementation | Tests |
+| --- | --- | --- |
+| Model catalog | [`model-catalog.ts`](../src/model-catalog.ts) | [`model-catalog.test.ts`](../src/model-catalog.test.ts) |
+| Model options | [`model-options.ts`](../src/model-options.ts) | [`model-options.test.ts`](../src/model-options.test.ts) |
+| OAuth | [`oauth.ts`](../src/oauth.ts) | [`oauth.test.ts`](../src/oauth.test.ts) |
+| Prompt cache | [`prompt-cache.ts`](../src/prompt-cache.ts) | [`prompt-cache.test.ts`](../src/prompt-cache.test.ts) |
+| Protocol identity | [`protocol.ts`](../src/protocol.ts) | [`protocol.test.ts`](../src/protocol.test.ts) |
+| Responses streaming | [`sse.ts`](../src/sse.ts) | [`sse.test.ts`](../src/sse.test.ts) |
+| Usage tracking | [`usage.ts`](../src/usage.ts) | [`usage.test.ts`](../src/usage.test.ts) |
+
+The VS Code integration entry points remain [`extension.ts`](../src/extension.ts)
+and [`provider.ts`](../src/provider.ts); their behavior is exercised through the
+Extension Development Host because both depend on the VS Code runtime.
+
 The ChatGPT Codex endpoint requires a bearer token plus the ChatGPT account ID extracted from OAuth JWT claims. Requests use `store: false` and send full conversation history. The provider derives a privacy-safe `prompt_cache_key` and matching cache-affinity `session-id` from the model, tools, instructions, and first user message, so both remain stable across normal chat turns, agent tool loops, and retries without storing prompt text locally. Each stateless backend request receives a fresh `thread-id`, preventing independent VS Code conversations with the same cache prefix from sharing a backend thread identity. The ChatGPT backend currently rejects the public Responses API's explicit `prompt_cache_options` and `prompt_cache_breakpoint` fields, so requests rely on the backend's automatic cache policy with the stable routing key.
 
 Shared protocol constants live in `protocol.ts`. OAuth and inference requests must use the extension originator and user agent defined there; do not identify requests as the official Codex CLI or OpenAI VS Code extension. The OAuth client and ChatGPT backend are undocumented integration surfaces and may change without notice.

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ The extension has three small layers:
 - `provider.ts` translates VS Code language-model messages and tools into stateless OpenAI Responses input items.
 - `sse.ts` incrementally parses Responses API events into VS Code text, thinking, usage, and tool-call parts.
 
-Each implementation stays beside its focused `node:test` coverage in `src/`:
+The following implementations have focused colocated `node:test` coverage in `src/`:
 
 | Area | Implementation | Tests |
 | --- | --- | --- |

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,8 +1,23 @@
+/** Shared error formatting for extension-facing and network failures. */
+
+/**
+ * Returns a useful message for any thrown value.
+ *
+ * @param error The value caught by the caller.
+ * @returns The error message, or a string representation of the value.
+ */
 export function messageOf(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
 }
 
+/**
+ * Builds an error from a non-successful HTTP response without exposing its body.
+ *
+ * @param prefix Context describing the failed request.
+ * @param response The response to inspect.
+ * @returns A normalized error for display or logging.
+ */
 export async function responseError(prefix: string, response: Response): Promise<Error> {
   const body = await response.text().catch(() => "");
   let detail = body.trim();

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -1,13 +1,21 @@
+/** Model-directory types and normalization for the live Codex picker. */
+
+/** Processing speed requested for a model. */
 export type SpeedMode = "normal" | "fast";
+/** A model-advertised reasoning effort. */
 export type ReasoningEffort = string;
+/** Reasoning summary modes accepted by the Codex backend. */
 export const REASONING_SUMMARIES = ["auto", "concise", "detailed", "none"] as const;
+/** A supported reasoning summary mode. */
 export type ReasoningSummary = typeof REASONING_SUMMARIES[number];
 
+/** One reasoning level advertised by the model directory. */
 export interface CodexReasoningLevel {
   effort: ReasoningEffort;
   description: string;
 }
 
+/** Normalized metadata for a model exposed by the extension. */
 export interface CodexModelMetadata {
   id: string;
   name: string;
@@ -27,6 +35,7 @@ export interface CodexModelMetadata {
   priority: number;
 }
 
+/** A picker-ready model entry, including its selected speed mode. */
 export interface CodexModelVariant extends CodexModelMetadata {
   registrationId: string;
   rawModelId: string;

--- a/src/model-options.ts
+++ b/src/model-options.ts
@@ -1,3 +1,5 @@
+/** Model-picker configuration and request-option translation. */
+
 import {
   REASONING_SUMMARIES,
   type CodexModelMetadata,
@@ -8,6 +10,7 @@ import {
 
 export type { ReasoningEffort, ReasoningSummary, SpeedMode } from "./model-catalog";
 
+/** Capabilities used to build a model's configuration controls. */
 export interface ModelOptionSpec {
   efforts: readonly ReasoningEffort[];
   descriptions: Readonly<Partial<Record<ReasoningEffort, string>>>;
@@ -18,6 +21,7 @@ export interface ModelOptionSpec {
   defaultReasoningSummary: ReasoningSummary;
 }
 
+/** Options resolved from the picker and workspace fallback settings. */
 export interface ModelRequestOptions {
   speedMode: SpeedMode;
   reasoningEffort: ReasoningEffort;

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,3 +1,5 @@
+/** PKCE sign-in, callback handling, refresh, and SecretStorage persistence. */
+
 import { createHash, randomBytes } from "node:crypto";
 import { createServer, type Server } from "node:http";
 import { homedir } from "node:os";
@@ -19,6 +21,7 @@ const CALLBACK_PATH = "/auth/callback";
 const SCOPE = "openid email profile offline_access";
 const SECRET_KEY = "openaiCodex.oauthSession.v1";
 
+/** Persisted OAuth credentials used for ChatGPT Codex requests. */
 export interface OAuthSession {
   accessToken: string;
   refreshToken: string;
@@ -27,12 +30,14 @@ export interface OAuthSession {
   email?: string;
 }
 
+/** Dependencies and callbacks for the interactive authorization flow. */
 export interface AuthorizationFlow {
   url: string;
   state: string;
   verifier: string;
 }
 
+/** Browser launch dependency used by interactive sign-in. */
 export interface BrowserSignIn {
   url: string;
   completion: Promise<OAuthSession>;
@@ -41,6 +46,12 @@ export interface BrowserSignIn {
 
 type Fetcher = typeof fetch;
 
+/**
+ * Owns the extension's OAuth session and refresh lifecycle.
+ *
+ * Credentials are stored in VS Code SecretStorage; callers receive only the
+ * access token and optional ChatGPT account identifier needed for a request.
+ */
 export class OpenAIOAuth {
   private refreshPromise: Promise<OAuthSession> | undefined;
 

--- a/src/prompt-cache.ts
+++ b/src/prompt-cache.ts
@@ -1,5 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
+/** Privacy-safe prompt-cache identity and transport helpers. */
+
 /**
  * Stable request-prefix inputs used to derive a privacy-safe prompt-cache key.
  *

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,3 +1,5 @@
+/** Stable protocol identity and endpoint constants for this extension. */
+
 export const EXTENSION_DISPLAY_NAME = "Codex Bridge for Copilot Chat";
 export const EXTENSION_PRODUCT_ID = "openai-oauth-copilot-chat";
 export const OAUTH_ORIGINATOR = EXTENSION_PRODUCT_ID;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,3 +1,5 @@
+/** VS Code language-model adapter for the ChatGPT Codex backend. */
+
 import { randomUUID } from "node:crypto";
 import * as vscode from "vscode";
 import { messageOf, responseError } from "./errors";
@@ -34,6 +36,7 @@ import {
 
 const DEFAULT_INSTRUCTIONS = "You are OpenAI Codex, a coding agent in Visual Studio Code. Be concise, correct, and use the supplied tools when useful.";
 
+/** Live model information registered with VS Code Chat. */
 export interface CodexModel extends vscode.LanguageModelChatInformation {
   rawModelId: string;
   speedMode: SpeedMode;

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -1,3 +1,6 @@
+/** Responses streaming primitives used by the VS Code provider. */
+
+/** A normalized event emitted by the Codex Responses SSE parser. */
 export interface CodexStreamEvent {
   text?: string;
   reasoning?: string;
@@ -8,10 +11,23 @@ export interface CodexStreamEvent {
   error?: string;
 }
 
+/**
+ * Incrementally parses server-sent events from the Codex Responses endpoint.
+ *
+ * The parser tolerates incomplete chunks and unknown event types so transport
+ * changes do not interrupt an otherwise valid response.
+ *
+ * @see {@link OpenAICodexProvider} in `provider.ts`
+ */
 export class ResponsesStreamParser {
   private buffer = "";
   private readonly toolArguments = new Map<string, string>();
 
+  /**
+   * Adds a transport chunk and returns every complete event it contains.
+   *
+   * @param chunk A UTF-8 SSE chunk decoded as text.
+   */
   push(chunk: string): CodexStreamEvent[] {
     this.buffer += chunk.replace(/\r\n/g, "\n");
     const events: CodexStreamEvent[] = [];
@@ -25,6 +41,7 @@ export class ResponsesStreamParser {
     return events;
   }
 
+  /** Flushes the final unterminated SSE block, if one exists. */
   finish(): CodexStreamEvent[] {
     const tail = this.buffer.trim();
     this.buffer = "";

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,3 +1,6 @@
+/** Usage payload normalization, local tracking, and display formatting. */
+
+/** Token counts reported by one Codex inference request. */
 export interface TokenUsage {
   modelId: string;
   recordedAt: number;
@@ -9,6 +12,7 @@ export interface TokenUsage {
   reasoningTokens?: number;
 }
 
+/** Locally accumulated token totals for the current extension session. */
 export interface TrackedTokenUsage {
   requests: number;
   promptTokens: number;
@@ -19,12 +23,14 @@ export interface TrackedTokenUsage {
   reasoningTokens: number;
 }
 
+/** One ChatGPT quota window and its reset information. */
 export interface RateLimitWindow {
   usedPercent: number;
   windowSeconds?: number;
   resetsAt?: number;
 }
 
+/** A named quota family beyond the primary and secondary windows. */
 export interface AdditionalRateLimit {
   id: string;
   name: string;
@@ -32,6 +38,7 @@ export interface AdditionalRateLimit {
   secondary?: RateLimitWindow;
 }
 
+/** Complete usage state shown by the extension. */
 export interface CodexUsageSnapshot {
   planType?: string;
   primary?: RateLimitWindow;
@@ -45,6 +52,7 @@ export interface CodexUsageSnapshot {
   updatedAt?: number;
 }
 
+/** Compact token payload sent to VS Code's language-model provider API. */
 export interface ProviderUsagePayload {
   prompt_tokens?: number;
   completion_tokens?: number;
@@ -53,6 +61,7 @@ export interface ProviderUsagePayload {
   completion_tokens_details?: { reasoning_tokens: number };
 }
 
+/** One row rendered in the usage quick pick. */
 export interface UsageDisplayRow {
   kind: "quota" | "tokens" | "tracked" | "credits" | "warning" | "empty";
   label: string;


### PR DESCRIPTION
## Summary

- add module and public API JSDoc across the extension source
- link related APIs with `@see` references
- document the colocated implementation/test source map in `docs/development.md`

## Why

The extension already keeps focused tests beside their implementations, but that structure and the relationships between modules were not documented consistently. This cleanup makes the source easier to navigate without changing runtime behavior.

## Validation

- `npm run check`
- `npm run package`
- `git diff --check`

The existing untracked `.codex/` directory was left out of the branch.