### PR TITLE
Add Codex banked reset credit controls

### DIFF
--- a/.changeset/bright-resets-remember.md
+++ b/.changeset/bright-resets-remember.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": patch
+---
+
+Show available Codex banked reset credits with expiry details and require explicit confirmation before redeeming a selected reset.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If another process uses local port `1455`, choose **Sign in manually**. If the C
 | Codex Bridge: Sign In Manually                            | Paste a callback URL when port 1455 is unavailable           |
 | Codex Bridge: Import Codex CLI Session (Advanced)         | Copy an existing local Codex CLI login after a warning       |
 | Codex Bridge: Test Connection                             | Send a small live request to the Codex backend               |
-| Codex Bridge: Show Usage                                  | Refresh and inspect subscription quota plus inference tokens |
+| Codex Bridge: Show Usage                                  | Refresh and inspect subscription quota, reset credits, and inference tokens |
 | Codex Bridge: Show Diagnostics                            | Show session presence and registered models without secrets  |
 
 ## Settings
@@ -86,7 +86,7 @@ selection overrides the workspace default.
 - `openaiCodex.debugLogging`: request metadata only; prompts and tokens are never logged
 - `openaiCodex.showUsageStatusBar`: show or hide the Codex quota/token indicator
 
-The status bar reads the same ChatGPT Codex quota endpoint used by Codex CLI and shows the primary and secondary utilization windows. Click it for reset times, the last inference token count, and cumulative tokens tracked by this extension on the current device.
+The status bar reads the same ChatGPT Codex quota endpoint used by Codex CLI and shows the primary and secondary utilization windows. Click it for reset times, available banked reset credits when the account exposes them, the last inference token count, and cumulative tokens tracked by this extension on the current device. A banked reset applies to both the 5-hour and weekly windows; redeeming one requires explicit confirmation.
 
 ## Documentation
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import {
   formatUsageRows,
   formatUsageStatusBar,
   formatUsageTooltip,
+  usageSnapshotForPersistence,
   type CodexUsageSnapshot,
   type UsageDisplayRow,
 } from "./usage";
@@ -33,7 +34,7 @@ export function activate(context: vscode.ExtensionContext): void {
     provider.onDidChangeUsage((usage) => {
       renderUsageStatus(usageStatus, usage);
       updateUsageStatusVisibility(usageStatus);
-      void context.globalState.update(USAGE_STATE_KEY, usage);
+      void context.globalState.update(USAGE_STATE_KEY, usageSnapshotForPersistence(usage));
     }),
     vscode.lm.registerLanguageModelChatProvider("openai-codex", provider),
     vscode.commands.registerCommand("openaiCodex.manage", () => manage(oauth, provider, output, usageStatus)),
@@ -190,6 +191,37 @@ async function showUsage(provider: OpenAICodexProvider, output: vscode.OutputCha
   });
   if (picked?.action === "refresh") await showUsage(provider, output);
   else if (picked?.action === "open") await vscode.env.openExternal(vscode.Uri.parse("https://chatgpt.com/codex"));
+  else if (picked?.action === "redeemReset" && picked.resetCreditId) await redeemReset(provider, output, picked.resetCreditId);
+}
+
+async function redeemReset(provider: OpenAICodexProvider, output: vscode.OutputChannel, creditId: string): Promise<void> {
+  const confirmation = await vscode.window.showWarningMessage(
+    "Redeem this Codex reset credit? It resets both the 5-hour and weekly usage windows and consumes one banked reset.",
+    { modal: true },
+    "Redeem reset",
+  );
+  if (confirmation !== "Redeem reset") return;
+  try {
+    const result = await vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Window, title: "Redeeming Codex reset credit…" },
+      () => provider.consumeResetCredit(creditId),
+    );
+    if (result.outcome === "reset") {
+      const windowText = result.windowsReset ? ` (${result.windowsReset} windows reset)` : "";
+      vscode.window.showInformationMessage(`Codex reset credit redeemed${windowText}.`);
+    } else if (result.outcome === "alreadyRedeemed") {
+      vscode.window.showInformationMessage("This Codex reset request was already redeemed.");
+    } else if (result.outcome === "noCredit") {
+      vscode.window.showWarningMessage("No Codex reset credit is currently available.");
+    } else if (result.outcome === "nothingToReset") {
+      vscode.window.showWarningMessage("There is no Codex usage window eligible for an immediate reset.");
+    } else {
+      vscode.window.showWarningMessage(`Codex reset response: ${result.outcome}`);
+    }
+    await showUsage(provider, output);
+  } catch (error) {
+    showError("Codex reset credit redemption failed", error, output);
+  }
 }
 
 function renderUsageStatus(item: vscode.StatusBarItem, snapshot: CodexUsageSnapshot): void {
@@ -203,19 +235,28 @@ function updateUsageStatusVisibility(item: vscode.StatusBarItem): void {
 }
 
 interface UsageQuickPickItem extends vscode.QuickPickItem {
-  action?: "refresh" | "open";
+  action?: "refresh" | "open" | "redeemReset";
+  resetCreditId?: string;
 }
 
 function toUsageQuickPickItem(row: UsageDisplayRow): UsageQuickPickItem {
   const icon = {
     quota: "$(pulse)",
+    reset: "$(refresh)",
     tokens: "$(symbol-numeric)",
     tracked: "$(history)",
     credits: "$(credit-card)",
     warning: "$(warning)",
     empty: "$(circle-slash)",
   }[row.kind];
-  return { label: `${icon} ${row.label}`, description: row.description, detail: row.detail, alwaysShow: true };
+  return {
+    label: `${icon} ${row.label}`,
+    description: row.description,
+    detail: row.detail,
+    alwaysShow: true,
+    action: row.action,
+    resetCreditId: row.actionId,
+  };
 }
 
 async function diagnostics(oauth: OpenAIOAuth, output: vscode.OutputChannel): Promise<void> {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -23,6 +23,8 @@ export const OPENAI_REDIRECT_URI = "http://localhost:1455/auth/callback";
 export const CODEX_MODELS_CLIENT_VERSION = "0.146.0";
 export const CHATGPT_CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
 export const CHATGPT_CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+export const CHATGPT_CODEX_RESET_CREDITS_URL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
+export const CHATGPT_CODEX_RESET_CREDIT_CONSUME_URL = `${CHATGPT_CODEX_RESET_CREDITS_URL}/consume`;
 
 /**
  * Builds the live Codex model-directory URL for a client version.

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -21,6 +21,8 @@ import { OpenAIOAuth } from "./oauth";
 import { buildPromptCacheRequestFields, createPromptCacheTransportHeaders } from "./prompt-cache";
 import {
   CODEX_MODELS_CLIENT_VERSION,
+  CHATGPT_CODEX_RESET_CREDIT_CONSUME_URL,
+  CHATGPT_CODEX_RESET_CREDITS_URL,
   CHATGPT_CODEX_RESPONSES_URL,
   CHATGPT_CODEX_USAGE_URL,
   chatgptCodexModelsUrl,
@@ -28,7 +30,10 @@ import {
 } from "./protocol";
 import { ResponsesStreamParser, type CodexStreamEvent } from "./sse";
 import {
+  buildResetCreditConsumePayload,
   mergeQuotaPayload,
+  mergeResetCreditsPayload,
+  parseResetCreditConsumePayload,
   recordRequestUsage,
   toProviderUsagePayload,
   type CodexUsageSnapshot,
@@ -93,13 +98,39 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     try {
       const response = await this.sendWithAuthRetry((credentials) => this.sendUsageRequest(credentials));
       if (!response.ok) throw await responseError("Unable to refresh OpenAI Codex usage", response);
-      this.lastQuotaFetchAt = Date.now();
-      this.setUsage(mergeQuotaPayload(this.usage, await response.json(), this.lastQuotaFetchAt));
+      const updatedAt = Date.now();
+      this.lastQuotaFetchAt = updatedAt;
+      let next = mergeQuotaPayload(this.usage, await response.json(), updatedAt);
+      try {
+        const resetCreditsResponse = await this.sendWithAuthRetry((credentials) => this.sendResetCreditsRequest(credentials));
+        if (!resetCreditsResponse.ok) {
+          next = { ...next, resetCredits: undefined, resetCreditsError: "The Codex backend did not provide reset-credit details" };
+        } else {
+          next = mergeResetCreditsPayload(next, await resetCreditsResponse.json(), updatedAt);
+        }
+      } catch {
+        // Reset-credit details are optional; quota refresh remains useful when this private endpoint changes.
+        next = { ...next, resetCredits: undefined, resetCreditsError: "Reset-credit details could not be refreshed" };
+      }
+      this.setUsage(next);
       return this.usage;
     } catch (error) {
       this.setUsage({ ...this.usage, error: messageOf(error), updatedAt: Date.now() });
       throw error;
     }
+  }
+
+  async consumeResetCredit(creditId: string): Promise<{ outcome: string; windowsReset?: number }> {
+    const redeemRequestId = randomUUID();
+    const response = await this.sendWithAuthRetry((credentials) => this.sendResetCreditConsumeRequest(credentials, creditId, redeemRequestId));
+    if (!response.ok) throw await responseError("Unable to redeem OpenAI Codex reset credit", response);
+    const result = parseResetCreditConsumePayload(await response.json());
+    try {
+      await this.refreshUsage();
+    } catch {
+      // The redemption result is authoritative even if the follow-up snapshot is temporarily unavailable.
+    }
+    return result;
   }
 
   /**
@@ -230,6 +261,31 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
   private sendUsageRequest(credentials: OAuthCredentials): Promise<Response> {
     return this.fetcher(CHATGPT_CODEX_USAGE_URL, {
       headers: this.authHeaders(credentials, "application/json"),
+    });
+  }
+
+  private sendResetCreditsRequest(credentials: OAuthCredentials): Promise<Response> {
+    return this.fetcher(CHATGPT_CODEX_RESET_CREDITS_URL, {
+      headers: {
+        ...this.authHeaders(credentials, "application/json"),
+        "OpenAI-Beta": "codex-1",
+      },
+    });
+  }
+
+  private sendResetCreditConsumeRequest(
+    credentials: OAuthCredentials,
+    creditId: string,
+    redeemRequestId: string,
+  ): Promise<Response> {
+    return this.fetcher(CHATGPT_CODEX_RESET_CREDIT_CONSUME_URL, {
+      method: "POST",
+      headers: {
+        ...this.authHeaders(credentials, "application/json"),
+        "Content-Type": "application/json",
+        "OpenAI-Beta": "codex-1",
+      },
+      body: JSON.stringify(buildResetCreditConsumePayload(creditId, redeemRequestId)),
     });
   }
 

--- a/src/usage.test.ts
+++ b/src/usage.test.ts
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildResetCreditConsumePayload,
   formatUsageStatusBar,
+  formatUsageRows,
   mergeQuotaPayload,
+  mergeResetCreditsPayload,
+  parseResetCreditConsumePayload,
   recordRequestUsage,
   toProviderUsagePayload,
+  usageSnapshotForPersistence,
 } from "./usage";
 
 test("normalizes Responses API usage for Copilot inference reporting", () => {
@@ -54,4 +59,51 @@ test("parses Codex primary and secondary subscription windows", () => {
   assert.deepEqual(snapshot.primary, { usedPercent: 18, windowSeconds: 18_000, resetsAt: 2_000_000 });
   assert.deepEqual(snapshot.secondary, { usedPercent: 42, windowSeconds: 604_800, resetsAt: 3_000_000 });
   assert.equal(formatUsageStatusBar(snapshot), "$(pulse) Codex 5h 18% · 7d 42%");
+});
+
+test("handles an account with no banked reset credits", () => {
+  const snapshot = mergeResetCreditsPayload({}, { available_count: 0, credits: [] }, 2_000);
+  assert.deepEqual(snapshot.resetCredits, { availableCount: 0, credits: [] });
+  assert.equal(snapshot.resetCreditsError, undefined);
+  assert.equal(formatUsageRows(snapshot).some((row) => row.kind === "reset"), false);
+});
+
+test("sorts reset credits by expiry and exposes only ephemeral redemption IDs", () => {
+  const snapshot = mergeResetCreditsPayload({}, {
+    available_count: 2,
+    credits: [
+      {
+        id: "later-credit",
+        title: "Full reset (Weekly + 5 hr)",
+        expires_at: "2026-08-30T00:00:00Z",
+        granted_at: "2026-07-31T00:00:00Z",
+      },
+      {
+        credit_id: "earlier-credit",
+        reset_type: "codexRateLimits",
+        expires_at: "2026-08-15T00:00:00Z",
+      },
+    ] as unknown,
+  }, 3_000);
+  const rows = formatUsageRows(snapshot, Date.parse("2026-08-07T00:00:00Z"));
+  assert.equal(rows[0].label, "Codex rate-limit reset");
+  assert.equal(rows[0].action, "redeemReset");
+  assert.equal(rows[0].actionId, "earlier-credit");
+  assert.equal(rows[1].actionId, "later-credit");
+  assert.equal(rows[0].description.includes("Expires"), true);
+
+  const persisted = usageSnapshotForPersistence(snapshot);
+  assert.equal(persisted.resetCredits?.credits?.[0].id, undefined);
+  assert.equal(persisted.resetCredits?.credits?.[1].id, undefined);
+});
+
+test("normalizes reset-credit consume outcomes and builds an idempotent request", () => {
+  assert.deepEqual(parseResetCreditConsumePayload({ code: "already_redeemed", windows_reset: 2 }), {
+    outcome: "alreadyRedeemed",
+    windowsReset: 2,
+  });
+  assert.deepEqual(buildResetCreditConsumePayload("credit-1", "request-1"), {
+    credit_id: "credit-1",
+    redeem_request_id: "request-1",
+  });
 });

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -31,6 +31,24 @@ export interface RateLimitWindow {
 }
 
 /** A named quota family beyond the primary and secondary windows. */
+
+/** One banked Codex rate-limit reset credit. */
+export interface RateLimitResetCredit {
+  id?: string;
+  resetType?: string;
+  status?: string;
+  grantedAt?: number;
+  expiresAt?: number;
+  title?: string;
+  description?: string;
+}
+
+/** Banked Codex reset credits returned by the account backend. */
+export interface RateLimitResetCredits {
+  availableCount: number;
+  credits?: RateLimitResetCredit[];
+}
+
 export interface AdditionalRateLimit {
   id: string;
   name: string;
@@ -46,6 +64,8 @@ export interface CodexUsageSnapshot {
   additional?: AdditionalRateLimit[];
   limitReached?: boolean;
   credits?: { hasCredits?: boolean; unlimited?: boolean; balance?: string };
+  resetCredits?: RateLimitResetCredits;
+  resetCreditsError?: string;
   lastRequest?: TokenUsage;
   tracked?: TrackedTokenUsage;
   error?: string;
@@ -63,10 +83,12 @@ export interface ProviderUsagePayload {
 
 /** One row rendered in the usage quick pick. */
 export interface UsageDisplayRow {
-  kind: "quota" | "tokens" | "tracked" | "credits" | "warning" | "empty";
+  kind: "quota" | "reset" | "tokens" | "tracked" | "credits" | "warning" | "empty";
   label: string;
   description: string;
   detail?: string;
+  action?: "redeemReset";
+  actionId?: string;
 }
 
 /**
@@ -178,6 +200,59 @@ export function mergeQuotaPayload(
   });
 }
 
+export function mergeResetCreditsPayload(
+  current: CodexUsageSnapshot,
+  raw: unknown,
+  updatedAt = Date.now(),
+): CodexUsageSnapshot {
+  const payload = asRecord(raw);
+  if (!payload) return { ...current, resetCreditsError: "OpenAI returned invalid reset-credit details", updatedAt };
+  const nested = asRecord(payload.rate_limit_reset_credits) ?? asRecord(payload.rateLimitResetCredits);
+  const source = nested ?? payload;
+  const rawCredits = Array.isArray(source.credits) ? source.credits : undefined;
+  const credits = rawCredits?.flatMap(parseResetCredit);
+  const availableCount = numberValue(source.available_count ?? source.availableCount);
+  if (availableCount === undefined && credits === undefined) {
+    return { ...current, resetCreditsError: "OpenAI returned invalid reset-credit details", updatedAt };
+  }
+  return {
+    ...current,
+    resetCredits: compactObject({
+      availableCount: availableCount ?? credits?.length ?? 0,
+      credits,
+    }),
+    resetCreditsError: undefined,
+    updatedAt,
+  };
+}
+
+export function parseResetCreditConsumePayload(raw: unknown): { outcome: string; windowsReset?: number } {
+  const payload = asRecord(raw);
+  const rawOutcome = stringValue(payload?.outcome) ?? stringValue(payload?.code);
+  if (!rawOutcome) throw new Error("OpenAI returned an invalid reset-credit response");
+  return compactObject({
+    outcome: normalizeResetCreditOutcome(rawOutcome),
+    windowsReset: numberValue(payload?.windows_reset ?? payload?.windowsReset),
+  });
+}
+
+export function buildResetCreditConsumePayload(creditId: string, redeemRequestId: string): { credit_id: string; redeem_request_id: string } {
+  return { credit_id: creditId, redeem_request_id: redeemRequestId };
+}
+
+/**
+ * Removes opaque reset-credit IDs before a usage snapshot is persisted in VS Code global state.
+ */
+export function usageSnapshotForPersistence(snapshot: CodexUsageSnapshot): CodexUsageSnapshot {
+  return {
+    ...snapshot,
+    resetCredits: snapshot.resetCredits ? {
+      availableCount: snapshot.resetCredits.availableCount,
+      credits: snapshot.resetCredits.credits?.map(({ id: _id, ...credit }) => credit),
+    } : undefined,
+  };
+}
+
 export function formatUsageStatusBar(snapshot: CodexUsageSnapshot): string {
   const windows = [snapshot.primary, snapshot.secondary].filter((value): value is RateLimitWindow => Boolean(value));
   if (windows.length) {
@@ -194,9 +269,11 @@ export function formatUsageTooltip(snapshot: CodexUsageSnapshot, now = Date.now(
   const lines = [`Codex Bridge usage${snapshot.planType ? ` (${snapshot.planType})` : ""}`];
   if (snapshot.primary) lines.push(windowSummary(snapshot.primary, now));
   if (snapshot.secondary) lines.push(windowSummary(snapshot.secondary, now));
+  if (snapshot.resetCredits?.availableCount) lines.push(`Reset credits: ${snapshot.resetCredits.availableCount}`);
   if (snapshot.lastRequest) lines.push(`Last request: ${requestSummary(snapshot.lastRequest)}`);
   if (snapshot.tracked) lines.push(`Tracked locally: ${snapshot.tracked.requests.toLocaleString()} requests · ${snapshot.tracked.totalTokens.toLocaleString()} tokens`);
   if (snapshot.credits?.balance) lines.push(`Credit balance: ${snapshot.credits.balance}`);
+  if (snapshot.resetCreditsError) lines.push(`Reset-credit refresh: ${snapshot.resetCreditsError}`);
   if (snapshot.error) lines.push(`Refresh error: ${snapshot.error}`);
   if (snapshot.updatedAt) lines.push(`Updated ${new Date(snapshot.updatedAt).toLocaleString()}`);
   lines.push("Click for details");
@@ -223,6 +300,17 @@ export function formatUsageRows(snapshot: CodexUsageSnapshot, now = Date.now()):
   for (const limit of snapshot.additional ?? []) {
     if (limit.primary) rows.push({ ...windowRow(limit.primary, now), label: limit.name });
   }
+  if (snapshot.resetCredits?.availableCount) {
+    const credits = [...(snapshot.resetCredits.credits ?? [])].sort((left, right) => (left.expiresAt ?? Number.POSITIVE_INFINITY) - (right.expiresAt ?? Number.POSITIVE_INFINITY));
+    for (const credit of credits) rows.push(resetCreditRow(credit, now));
+    const undisclosedCount = snapshot.resetCredits.availableCount - credits.length;
+    if (!credits.length || undisclosedCount > 0) rows.push({
+      kind: "reset",
+      label: `${snapshot.resetCredits.availableCount.toLocaleString()} reset credit${snapshot.resetCredits.availableCount === 1 ? "" : "s"} available`,
+      description: credits.length ? `${undisclosedCount.toLocaleString()} credit detail${undisclosedCount === 1 ? "" : "s"} unavailable` : "Credit details unavailable",
+      detail: "Refresh usage to try again",
+    });
+  }
   if (snapshot.lastRequest) rows.push({
     kind: "tokens",
     label: "Last inference",
@@ -241,8 +329,28 @@ export function formatUsageRows(snapshot: CodexUsageSnapshot, now = Date.now()):
     description: snapshot.credits.unlimited ? "Unlimited" : snapshot.credits.balance ?? "Available",
   });
   if (snapshot.error) rows.push({ kind: "warning", label: "Usage refresh failed", description: snapshot.error });
+  if (snapshot.resetCreditsError) rows.push({ kind: "warning", label: "Reset credits unavailable", description: snapshot.resetCreditsError });
   if (!rows.length) rows.push({ kind: "empty", label: "No usage observed yet", description: "Send a Codex request or refresh usage" });
   return rows;
+}
+
+function resetCreditRow(credit: RateLimitResetCredit, now: number): UsageDisplayRow {
+  const description = credit.expiresAt
+    ? `Expires ${formatDate(credit.expiresAt)} (${formatReset(credit.expiresAt, now)})`
+    : "Expiry unavailable";
+  const detail = [
+    credit.description,
+    credit.grantedAt ? `Granted ${formatDate(credit.grantedAt)}` : undefined,
+    credit.status && credit.status !== "available" ? `Status: ${credit.status}` : undefined,
+  ].filter((value): value is string => Boolean(value)).join(" · ");
+  return {
+    kind: "reset",
+    label: credit.title ?? resetCreditTypeLabel(credit.resetType),
+    description,
+    detail: detail || "Redeems both the 5-hour and weekly Codex windows",
+    action: credit.id ? "redeemReset" : undefined,
+    actionId: credit.id,
+  };
 }
 
 function normalizeTokenUsage(raw: Record<string, unknown>): Omit<TokenUsage, "modelId" | "recordedAt"> {
@@ -273,6 +381,21 @@ function parseWindow(value: unknown): RateLimitWindow | undefined {
     windowSeconds: numberValue(raw.limit_window_seconds),
     resetsAt: resetAtSeconds === undefined ? undefined : resetAtSeconds * 1000,
   });
+}
+
+function parseResetCredit(value: unknown): RateLimitResetCredit[] {
+  const raw = asRecord(value);
+  if (!raw) return [];
+  const credit = compactObject({
+    id: stringValue(raw.id) ?? stringValue(raw.credit_id) ?? stringValue(raw.creditId),
+    resetType: stringValue(raw.reset_type) ?? stringValue(raw.resetType),
+    status: stringValue(raw.status),
+    grantedAt: timestampValue(raw.granted_at ?? raw.grantedAt),
+    expiresAt: timestampValue(raw.expires_at ?? raw.expiresAt),
+    title: stringValue(raw.title) ?? stringValue(raw.name),
+    description: stringValue(raw.description),
+  });
+  return Object.keys(credit).length ? [credit] : [];
 }
 
 function windowRow(window: RateLimitWindow, now: number): UsageDisplayRow {
@@ -318,6 +441,24 @@ function formatReset(resetsAt: number, now: number): string {
   return `in ${hours}h${remainder ? ` ${remainder}m` : ""}`;
 }
 
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+function resetCreditTypeLabel(resetType: string | undefined): string {
+  if (!resetType) return "Codex reset credit";
+  if (resetType.toLowerCase().includes("codex")) return "Codex rate-limit reset";
+  return `${resetType} reset`;
+}
+
+function normalizeResetCreditOutcome(outcome: string): string {
+  return ({
+    already_redeemed: "alreadyRedeemed",
+    nothing_to_reset: "nothingToReset",
+    no_credit: "noCredit",
+  } as Record<string, string>)[outcome] ?? outcome;
+}
+
 function compactCount(value: number | undefined): string {
   if (value === undefined) return "?";
   if (value >= 10_000) return `${Math.round(value / 1000)}k`;
@@ -332,6 +473,17 @@ function exactCount(value: number | undefined): string {
 function numberValue(value: unknown): number | undefined {
   const parsed = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function timestampValue(value: unknown): number | undefined {
+  if (typeof value === "number" || (typeof value === "string" && value.trim() && !Number.isNaN(Number(value)))) {
+    const parsed = numberValue(value);
+    if (parsed === undefined) return undefined;
+    return parsed < 100_000_000_000 ? parsed * 1000 : parsed;
+  }
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function stringValue(value: unknown): string | undefined {


### PR DESCRIPTION
## Summary

- display available Codex banked reset credits with expiry and grant details
- sort reset credits by earliest expiry
- add explicit confirmation before redeeming a selected reset credit
- refresh quota and reset-credit state after redemption
- avoid persisting opaque reset-credit IDs in VS Code global state
- keep quota refresh working when the reset-credit endpoint is unavailable

## Why

Discussion #3 requested visibility into multiple Codex usage resets and a way to redeem them individually. This first pass treats them as banked reset credits: redeeming one resets both the 5-hour and weekly Codex windows.

The implementation uses the same authenticated ChatGPT backend integration already used for quota refresh. The reset-credit endpoint is undocumented, so parsing is defensive and the feature degrades without breaking ordinary usage refresh.

## Verification

- `npm run check` — 39 tests passed
- `npm run package` — VSIX packaging succeeded
- `git diff --check` — clean
- synthetic coverage includes zero credits, multiple credits sorted by expiry, snake/camel payload variants, idempotent consume payloads, and redaction of opaque IDs before persistence

Live redemption was not performed because the test account has no reset credits.

## Follow-up

- validate the live flow with an account that has a reset credit
- consider migrating to the supported Codex app-server rate-limit protocol when the extension can share authentication cleanly
