### PR TITLE
Fix reset-credit routing and availability

### DIFF
--- a/.changeset/quiet-credits-target.md
+++ b/.changeset/quiet-credits-target.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": patch
+---
+
+Harden Codex reset-credit requests with originator and account routing, and prevent non-available credits from being redeemable.

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -268,6 +268,7 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     return this.fetcher(CHATGPT_CODEX_RESET_CREDITS_URL, {
       headers: {
         ...this.authHeaders(credentials, "application/json"),
+        Originator: OAUTH_ORIGINATOR,
         "OpenAI-Beta": "codex-1",
       },
     });
@@ -283,9 +284,10 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
       headers: {
         ...this.authHeaders(credentials, "application/json"),
         "Content-Type": "application/json",
+        Originator: OAUTH_ORIGINATOR,
         "OpenAI-Beta": "codex-1",
       },
-      body: JSON.stringify(buildResetCreditConsumePayload(creditId, redeemRequestId)),
+      body: JSON.stringify(buildResetCreditConsumePayload(creditId, redeemRequestId, credentials.accountId)),
     });
   }
 

--- a/src/usage.test.ts
+++ b/src/usage.test.ts
@@ -75,12 +75,14 @@ test("sorts reset credits by expiry and exposes only ephemeral redemption IDs", 
       {
         id: "later-credit",
         title: "Full reset (Weekly + 5 hr)",
+        status: "available",
         expires_at: "2026-08-30T00:00:00Z",
         granted_at: "2026-07-31T00:00:00Z",
       },
       {
         credit_id: "earlier-credit",
         reset_type: "codexRateLimits",
+        status: "available",
         expires_at: "2026-08-15T00:00:00Z",
       },
     ] as unknown,
@@ -97,13 +99,32 @@ test("sorts reset credits by expiry and exposes only ephemeral redemption IDs", 
   assert.equal(persisted.resetCredits?.credits?.[1].id, undefined);
 });
 
-test("normalizes reset-credit consume outcomes and builds an idempotent request", () => {
+test("only exposes available reset credits as redeemable", () => {
+  const snapshot = mergeResetCreditsPayload({}, {
+    available_count: 2,
+    credits: [
+      { id: "available-credit", status: "available" },
+      { id: "redeemed-credit", status: "redeemed" },
+    ],
+  });
+  const rows = formatUsageRows(snapshot);
+  assert.equal(rows[0].actionId, "available-credit");
+  assert.equal(rows[1].action, undefined);
+  assert.equal(rows[1].actionId, undefined);
+});
+
+test("normalizes reset-credit consume outcomes and builds account-scoped requests", () => {
   assert.deepEqual(parseResetCreditConsumePayload({ code: "already_redeemed", windows_reset: 2 }), {
     outcome: "alreadyRedeemed",
     windowsReset: 2,
   });
-  assert.deepEqual(buildResetCreditConsumePayload("credit-1", "request-1"), {
+  assert.deepEqual(buildResetCreditConsumePayload("credit-1", "request-1", "account-1"), {
     credit_id: "credit-1",
     redeem_request_id: "request-1",
+    account_id: "account-1",
+  });
+  assert.deepEqual(buildResetCreditConsumePayload("credit-1", "request-2"), {
+    credit_id: "credit-1",
+    redeem_request_id: "request-2",
   });
 });

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -236,8 +236,12 @@ export function parseResetCreditConsumePayload(raw: unknown): { outcome: string;
   });
 }
 
-export function buildResetCreditConsumePayload(creditId: string, redeemRequestId: string): { credit_id: string; redeem_request_id: string } {
-  return { credit_id: creditId, redeem_request_id: redeemRequestId };
+export function buildResetCreditConsumePayload(
+  creditId: string,
+  redeemRequestId: string,
+  accountId?: string,
+): { credit_id: string; redeem_request_id: string; account_id?: string } {
+  return compactObject({ credit_id: creditId, redeem_request_id: redeemRequestId, account_id: accountId });
 }
 
 /**
@@ -348,8 +352,8 @@ function resetCreditRow(credit: RateLimitResetCredit, now: number): UsageDisplay
     label: credit.title ?? resetCreditTypeLabel(credit.resetType),
     description,
     detail: detail || "Redeems both the 5-hour and weekly Codex windows",
-    action: credit.id ? "redeemReset" : undefined,
-    actionId: credit.id,
+    action: credit.id && credit.status === "available" ? "redeemReset" : undefined,
+    actionId: credit.id && credit.status === "available" ? credit.id : undefined,
   };
 }
 


### PR DESCRIPTION
Addresses the missed review feedback from PR #16 review 4879111104.

- send Originator on reset-credit retrieval and consumption
- include account_id in consume payloads when available
- only expose reset credits with status "available" as redeemable
- add coverage for account-present/absent payloads and non-available credits
- add a patch changeset for the next release

Verification:
- npm run check — 40 tests passed
- npm run package — VSIX packaging succeeded