### PR TITLE
Add opt-in web search model toggle

### DIFF
--- a/.changeset/quick-web-search.md
+++ b/.changeset/quick-web-search.md
@@ -1,5 +1,5 @@
 ---
-"openai-oauth-copilot-chat": patch
+"openai-oauth-copilot-chat": minor
 ---
 
 Add an opt-in Web Search toggle beside the model reasoning controls and forward hosted Responses API search annotations to Copilot.

--- a/.changeset/quick-web-search.md
+++ b/.changeset/quick-web-search.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": patch
+---
+
+Add an opt-in Web Search toggle beside the model reasoning controls and forward hosted Responses API search annotations to Copilot.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This extension is a native VS Code `LanguageModelChatProvider`. It handles OpenA
 - ChatGPT OAuth with PKCE and automatic access-token refresh
 - Models discovered from the live Codex catalog for the signed-in ChatGPT account
 - Streaming responses, reasoning summaries, images, and tool calling
-- Per-model reasoning effort and Speed Mode controls
+- Per-model reasoning effort, opt-in Web Search, and Speed Mode controls
 - Native Copilot context-window accounting from Codex inference token usage
 - Automatic OpenAI prompt-cache reuse for eligible prefixes across normal chat turns and agent tool loops
 - Status-bar indicator for five-hour/weekly ChatGPT Codex quota and locally tracked tokens
@@ -32,6 +32,10 @@ extension. Display names, descriptions, context windows, image/tool capabilities
 reasoning efforts, and Fast availability are derived from the signed-in account's
 catalog response. Models that advertise the `fast` additional speed tier expose a native
 **Speed Mode** control on their normal model entry.
+Every model also exposes an opt-in **Web Search** control beside its reasoning
+controls. It is disabled by default; when enabled, the request includes the
+Codex Responses API's hosted `web_search` tool and preserves streamed search
+annotations as provider data.
 
 Context limits follow Codex's own runtime policy: the catalog's effective-window
 percentage defines the usable hard window, while its auto-compaction threshold defines
@@ -81,6 +85,8 @@ reasoning efforts advertised by that catalog. Fast processing can be selected th
 the model's native **Speed Mode** control; it uses more account capacity.
 Models that accept `reasoning.summary` also expose a per-model summary control; that
 selection overrides the workspace default.
+**Web Search** is an independent per-model toggle and remains disabled unless selected
+in the model picker.
 
 - `openaiCodex.requestTimeoutSeconds`: total request timeout
 - `openaiCodex.debugLogging`: request metadata only; prompts and tokens are never logged

--- a/src/model-options.test.ts
+++ b/src/model-options.test.ts
@@ -24,7 +24,7 @@ const spec: ModelOptionSpec = {
 test("resolves picker options and applies them to a Fast request", () => {
   const options = resolveModelRequestOptions(
     spec,
-    { reasoningEffort: "adaptive", reasoningSummary: "detailed" },
+    { reasoningEffort: "adaptive", reasoningSummary: "detailed", webSearch: true },
     { reasoningSummary: "concise" },
     "fast",
   );
@@ -33,6 +33,7 @@ test("resolves picker options and applies them to a Fast request", () => {
     speedMode: "fast",
     reasoningEffort: "adaptive",
     reasoningSummary: "detailed",
+    webSearch: true,
   });
   assert.deepEqual(applyModelRequestOptions({ model: "gpt-5.6-sol" }, options), {
     model: "gpt-5.6-sol",
@@ -65,7 +66,7 @@ test("falls back to live model defaults and reads legacy picker values", () => {
       { reasoningEffort: "adaptive", reasoningSummary: "model" },
       "normal",
     ),
-    { speedMode: "normal", reasoningEffort: "medium", reasoningSummary: "auto" },
+    { speedMode: "normal", reasoningEffort: "medium", reasoningSummary: "auto", webSearch: false },
   );
   assert.equal(
     resolveModelRequestOptions(spec, { mode: "fast:adaptive" }, {}, "normal").reasoningEffort,
@@ -81,7 +82,7 @@ test("retains legacy workspace effort and speed fallbacks", () => {
       { reasoningEffort: "adaptive", speedMode: "fast", reasoningSummary: "model" },
       "normal",
     ),
-    { speedMode: "fast", reasoningEffort: "adaptive", reasoningSummary: "auto" },
+    { speedMode: "fast", reasoningEffort: "adaptive", reasoningSummary: "auto", webSearch: false },
   );
   assert.equal(
     resolveModelRequestOptions({ ...spec, supportsFast: false }, undefined, { speedMode: "fast" }, "normal").speedMode,
@@ -98,6 +99,7 @@ test("builds picker controls from the live model metadata", () => {
     speedMode: "normal",
     reasoningEffort: "adaptive",
     reasoningSummary: "concise",
+    webSearch: false,
   });
 
   assert.deepEqual(schema.properties.reasoningEffort.enum, ["medium", "adaptive"]);
@@ -106,6 +108,10 @@ test("builds picker controls from the live model metadata", () => {
     "Let the model choose",
   ]);
   assert.equal(schema.properties.reasoningEffort.default, "adaptive");
+  assert.equal(schema.properties.webSearch.type, "boolean");
+  assert.equal(schema.properties.webSearch.title, "Web Search");
+  assert.equal(schema.properties.webSearch.default, false);
+  assert.equal(schema.properties.webSearch.group, "navigation");
   assert.deepEqual(schema.properties.speedMode.enum, ["normal", "fast"]);
   assert.deepEqual(schema.properties.speedMode.enumDescriptions, [
     "Standard speed and usage",
@@ -119,9 +125,11 @@ test("builds picker controls from the live model metadata", () => {
     speedMode: "fast",
     reasoningEffort: "adaptive",
     reasoningSummary: "concise",
+    webSearch: false,
   });
   assert.deepEqual(legacyFastDefaultSchema.properties.speedMode.enum, ["normal", "fast"]);
   assert.equal(legacyFastDefaultSchema.properties.speedMode.default, "fast");
+  assert.equal(legacyFastDefaultSchema.properties.webSearch.default, false);
 
   const unsupported = buildModelConfigurationSchema({
     ...spec,

--- a/src/model-options.ts
+++ b/src/model-options.ts
@@ -26,6 +26,7 @@ export interface ModelRequestOptions {
   speedMode: SpeedMode;
   reasoningEffort: ReasoningEffort;
   reasoningSummary: ReasoningSummary;
+  webSearch: boolean;
 }
 
 /**
@@ -87,6 +88,8 @@ export function resolveModelRequestOptions(
     ?? parseConfiguredEffort(stringOption(workspaceDefaults, "reasoningEffort"));
   const requestedSummary = parseConfiguredSummary(stringOption(requestConfiguration, "reasoningSummary"))
     ?? parseConfiguredSummary(stringOption(workspaceDefaults, "reasoningSummary"));
+  const requestedWebSearch = booleanOption(requestConfiguration, "webSearch")
+    ?? booleanOption(workspaceDefaults, "webSearch");
   const requestedSpeed = parseConfiguredSpeed(stringOption(requestConfiguration, "speedMode"))
     ?? legacyMode?.speedMode
     ?? parseConfiguredSpeed(stringOption(workspaceDefaults, "speedMode"));
@@ -98,6 +101,7 @@ export function resolveModelRequestOptions(
     reasoningSummary: requestedSummary === "model" || requestedSummary === undefined
       ? spec.defaultReasoningSummary
       : requestedSummary,
+    webSearch: requestedWebSearch ?? false,
     speedMode: speedMode === "fast"
       ? "fast"
       : spec.supportsFast && requestedSpeed === "fast" ? "fast" : "normal",
@@ -146,6 +150,13 @@ export function buildModelConfigurationSchema(
         default: defaultEffort,
         group: "navigation",
       },
+      webSearch: {
+        type: "boolean",
+        title: "Web Search",
+        description: "Allow Codex to use OpenAI-hosted web search for this model.",
+        default: defaults?.webSearch ?? false,
+        group: "navigation",
+      },
       ...(exposesSpeedMode ? {
         speedMode: {
           type: "string",
@@ -187,7 +198,7 @@ export function buildModelConfigurationSchema(
  * ```ts
  * const body = applyModelRequestOptions(
  *   { model: "gpt-5", stream: true },
- *   { speedMode: "fast", reasoningEffort: "high", reasoningSummary: "concise" },
+ *   { speedMode: "fast", reasoningEffort: "high", reasoningSummary: "concise", webSearch: false },
  * );
  * ```
  *
@@ -213,6 +224,10 @@ export function applyModelRequestOptions(
 
 function stringOption(value: Readonly<Record<string, unknown>> | undefined, key: string): string | undefined {
   return typeof value?.[key] === "string" ? value[key] as string : undefined;
+}
+
+function booleanOption(value: Readonly<Record<string, unknown>> | undefined, key: string): boolean | undefined {
+  return typeof value?.[key] === "boolean" ? value[key] as boolean : undefined;
 }
 
 function parseConfiguredEffort(value: string | undefined): ReasoningEffort | undefined {

--- a/src/native-tools.test.ts
+++ b/src/native-tools.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildNativeTools } from "./native-tools";
+
+test("keeps hosted web search disabled by default", () => {
+  assert.deepEqual(buildNativeTools({ webSearch: false }), []);
+});
+
+test("builds the Responses web-search descriptor when opted in", () => {
+  assert.deepEqual(buildNativeTools({ webSearch: true }), [{ type: "web_search" }]);
+});

--- a/src/native-tools.ts
+++ b/src/native-tools.ts
@@ -1,0 +1,8 @@
+/** OpenAI-hosted Responses tools enabled by model-picker options. */
+
+import type { ModelRequestOptions } from "./model-options";
+
+/** Builds the provider-owned native tool descriptors for one request. */
+export function buildNativeTools(options: Pick<ModelRequestOptions, "webSearch">): Record<string, unknown>[] {
+  return options.webSearch ? [{ type: "web_search" }] : [];
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -17,6 +17,7 @@ import {
   parseCodexModelsPayload,
   type CodexModelMetadata,
 } from "./model-catalog";
+import { buildNativeTools } from "./native-tools";
 import { OpenAIOAuth } from "./oauth";
 import { buildPromptCacheRequestFields, createPromptCacheTransportHeaders } from "./prompt-cache";
 import {
@@ -196,7 +197,7 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     if (!response.body) throw new Error("OpenAI Codex returned an empty response stream");
 
     if (configuration().get("debugLogging", false)) {
-      this.output.appendLine(`[request] model=${model.rawModelId} speed=${requestOptions.speedMode} effort=${requestOptions.reasoningEffort} summary=${requestOptions.reasoningSummary} initiator=${options.requestInitiator ?? "unknown"}`);
+      this.output.appendLine(`[request] model=${model.rawModelId} speed=${requestOptions.speedMode} effort=${requestOptions.reasoningEffort} summary=${requestOptions.reasoningSummary} webSearch=${requestOptions.webSearch} initiator=${options.requestInitiator ?? "unknown"}`);
     }
     await consumeStream(response.body, progress, token, (usage) => this.captureRequestUsage(usage, model.rawModelId));
     if (Date.now() - this.lastQuotaFetchAt > 60_000) {
@@ -416,6 +417,8 @@ function buildRequest(
     parameters: tool.inputSchema && typeof tool.inputSchema === "object" ? tool.inputSchema : { type: "object", properties: {} },
     strict: false,
   }));
+  const nativeTools = buildNativeTools(requestOptions);
+  const allTools = [...nativeTools, ...tools];
   const convertedInput = messages.flatMap(convertMessage);
   const input = convertedInput.length
     ? convertedInput
@@ -423,7 +426,7 @@ function buildRequest(
   const promptCache = buildPromptCacheRequestFields({
     model,
     instructions: DEFAULT_INSTRUCTIONS,
-    tools,
+    tools: allTools,
     input,
   });
   return applyModelRequestOptions({
@@ -433,8 +436,8 @@ function buildRequest(
     store: false,
     stream: true,
     include: ["reasoning.encrypted_content"],
-    ...(tools.length ? {
-      tools,
+    ...(allTools.length ? {
+      tools: allTools,
       tool_choice: options.toolMode === vscode.LanguageModelChatToolMode.Required ? "required" : "auto",
       parallel_tool_calls: supportsParallelToolCalls,
     } : {}),
@@ -511,10 +514,27 @@ function reportEvent(event: CodexStreamEvent, progress: vscode.Progress<vscode.L
   if (event.toolCall) {
     progress.report(new vscode.LanguageModelToolCallPart(event.toolCall.id, event.toolCall.name, parseArguments(event.toolCall.arguments)));
   }
+  if (event.webSearchCall) {
+    reportDataPart(progress, "web-search", event.webSearchCall);
+  }
+  if (event.webSearchAnnotation) {
+    reportDataPart(progress, "web-search-annotation", event.webSearchAnnotation);
+  }
   if (event.usage) {
     const usage = toProviderUsagePayload(event.usage);
     if (usage) progress.report(new vscode.LanguageModelDataPart(new TextEncoder().encode(JSON.stringify(usage)), "usage"));
   }
+}
+
+function reportDataPart(
+  progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
+  kind: string,
+  value: Record<string, unknown>,
+): void {
+  progress.report(new vscode.LanguageModelDataPart(
+    new TextEncoder().encode(JSON.stringify({ kind, ...value })),
+    "application/vnd.openai.web-search+json",
+  ));
 }
 
 function parseArguments(value: string): object {

--- a/src/sse.test.ts
+++ b/src/sse.test.ts
@@ -35,6 +35,19 @@ test("emits completed function calls", () => {
   assert.deepEqual(events, [{ toolCall: { id: "c1", name: "read_file", arguments: '{"path":"a"}' } }]);
 });
 
+test("preserves hosted web-search calls and citations as data events", () => {
+  const parser = new ResponsesStreamParser();
+  const events = parser.push([
+    'data: {"type":"response.output_item.done","item":{"type":"web_search_call","id":"ws1","status":"completed","action":{"type":"search","queries":["latest OpenAI news"]}}}',
+    'data: {"type":"response.output_text.annotation.added","annotation":{"type":"url_citation","url":"https://example.com","title":"Example"}}',
+  ].join("\n\n") + "\n\n");
+
+  assert.deepEqual(events, [
+    { webSearchCall: { id: "ws1", status: "completed", action: { type: "search", queries: ["latest OpenAI news"] } } },
+    { webSearchAnnotation: { type: "url_citation", url: "https://example.com", title: "Example" } },
+  ]);
+});
+
 test("preserves encrypted reasoning for stateless follow-up requests", () => {
   const parser = new ResponsesStreamParser();
   const events = parser.push('data: {"type":"response.output_item.done","item":{"type":"reasoning","id":"r1","encrypted_content":"ciphertext"}}\n\n');

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -7,6 +7,8 @@ export interface CodexStreamEvent {
   reasoningBoundary?: true;
   encryptedReasoning?: { id: string; data: string };
   toolCall?: { id: string; name: string; arguments: string };
+  webSearchCall?: { id: string; status?: string; action?: Record<string, unknown> };
+  webSearchAnnotation?: Record<string, unknown>;
   usage?: Record<string, unknown>;
   error?: string;
 }
@@ -74,12 +76,23 @@ export class ResponsesStreamParser {
       this.toolArguments.set(id, (this.toolArguments.get(id) ?? "") + delta);
       return undefined;
     }
+    if (type === "response.output_text.annotation.added") {
+      const annotation = recordField(value, "annotation");
+      return annotation ? [{ webSearchAnnotation: annotation }] : undefined;
+    }
     if (type === "response.output_item.done") {
       const item = recordField(value, "item");
       if (item?.type === "function_call") {
         const id = stringField(item, "call_id") ?? stringField(item, "id") ?? `codex-tool-${Date.now()}`;
         const args = stringField(item, "arguments") ?? this.toolArguments.get(stringField(item, "id") ?? id) ?? "{}";
         return [{ toolCall: { id, name: stringField(item, "name") ?? "tool", arguments: args } }];
+      }
+      if (item?.type === "web_search_call") {
+        return [{ webSearchCall: {
+          id: stringField(item, "id") ?? `web-search-${Date.now()}`,
+          status: stringField(item, "status"),
+          action: recordField(item, "action"),
+        } }];
       }
       if (item?.type === "reasoning") {
         const encrypted = stringField(item, "encrypted_content");


### PR DESCRIPTION
## What changed

- Add a default-off `Web Search` boolean to the per-model Copilot configuration schema, grouped beside reasoning controls.
- Add provider-owned Responses native-tool composition for `{ type: "web_search" }` while preserving the existing Copilot function-tool path.
- Parse hosted web-search lifecycle output and streamed URL annotations into provider data parts.
- Add focused option, native-tool, and SSE coverage, update the README, and include a patch changeset.

## User impact

Users can enable Web Search per Codex model from the model picker. Existing models and requests remain unchanged unless the toggle is selected.

## Validation

- `npm run check` — 43 tests passed.
- `npm run package` — VSIX packaged successfully.

Live authentication/backend behavior was not exercised in the extension host; the private ChatGPT Codex endpoint remains an undocumented compatibility surface.
