### PR TITLE
Add native image generation support

### DIFF
--- a/.changeset/native-image-generation.md
+++ b/.changeset/native-image-generation.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": minor
+---
+
+Add opt-in native image generation through the Codex Responses provider, including streamed image output in Copilot Chat.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This extension is a native VS Code `LanguageModelChatProvider`. It handles OpenA
 - ChatGPT OAuth with PKCE and automatic access-token refresh
 - Models discovered from the live Codex catalog for the signed-in ChatGPT account
 - Streaming responses, reasoning summaries, images, and tool calling
-- Per-model reasoning effort, opt-in Web Search, and Speed Mode controls
+- Per-model reasoning effort, opt-in Web Search, Image Generation, and Speed Mode controls
 - Native Copilot context-window accounting from Codex inference token usage
 - Automatic OpenAI prompt-cache reuse for eligible prefixes across normal chat turns and agent tool loops
 - Status-bar indicator for five-hour/weekly ChatGPT Codex quota and locally tracked tokens
@@ -36,6 +36,10 @@ Every model also exposes an opt-in **Web Search** control beside its reasoning
 controls. It is disabled by default; when enabled, the request includes the
 Codex Responses API's hosted `web_search` tool and preserves streamed search
 annotations as provider data.
+The **Image Generation** control is also disabled by default; when enabled, the
+request includes the hosted `image_generation` tool and streams generated image
+data back into Copilot Chat. Availability depends on the signed-in Codex backend
+and selected model accepting that hosted tool.
 
 Context limits follow Codex's own runtime policy: the catalog's effective-window
 percentage defines the usable hard window, while its auto-compaction threshold defines
@@ -87,6 +91,9 @@ Models that accept `reasoning.summary` also expose a per-model summary control; 
 selection overrides the workspace default.
 **Web Search** is an independent per-model toggle and remains disabled unless selected
 in the model picker.
+**Image Generation** is an independent per-model toggle and remains disabled unless
+selected in the model picker. Generated images are returned directly in the chat
+response; the backend must support the hosted Responses image-generation tool.
 
 - `openaiCodex.requestTimeoutSeconds`: total request timeout
 - `openaiCodex.debugLogging`: request metadata only; prompts and tokens are never logged

--- a/src/image-data.test.ts
+++ b/src/image-data.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { decodeGeneratedImage } from "./image-data";
+
+test("decodes a PNG result and detects its MIME type", () => {
+  const result = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).toString("base64");
+  const image = decodeGeneratedImage(result);
+  assert.equal(image.mimeType, "image/png");
+  assert.deepEqual([...image.data], [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+});
+
+test("preserves a data URL MIME type", () => {
+  const result = `data:image/jpeg;base64,${Buffer.from([0xff, 0xd8, 0xff]).toString("base64")}`;
+  assert.equal(decodeGeneratedImage(result).mimeType, "image/jpeg");
+});
+
+test("rejects malformed image results", () => {
+  assert.throws(() => decodeGeneratedImage("not base64?"), /invalid generated image/);
+  assert.throws(() => decodeGeneratedImage(""), /invalid generated image/);
+});

--- a/src/image-data.ts
+++ b/src/image-data.ts
@@ -1,0 +1,41 @@
+/** Converts Responses image-generation results into VS Code image data. */
+
+export interface GeneratedImage {
+  data: Uint8Array;
+  mimeType: string;
+}
+
+/**
+ * Decodes the base64 result returned by the Responses image-generation tool.
+ * Data URLs preserve their declared MIME type; bare results use signatures
+ * when available and otherwise follow the API's default PNG output.
+ */
+export function decodeGeneratedImage(result: string): GeneratedImage {
+  const dataUrl = /^data:(image\/[a-z0-9.+-]+);base64,(.*)$/is.exec(result.trim());
+  const mimeType = dataUrl?.[1]?.toLowerCase();
+  const encoded = dataUrl?.[2] ?? result;
+  const normalized = encoded.replace(/\s+/g, "").replace(/-/g, "+").replace(/_/g, "/");
+  if (!normalized || !/^[a-z0-9+/]*={0,2}$/i.test(normalized)) {
+    throw new Error("Codex returned an invalid generated image result");
+  }
+
+  const data = Buffer.from(normalized, "base64");
+  if (!data.length) throw new Error("Codex returned an empty generated image result");
+  return { data, mimeType: mimeType ?? detectImageMimeType(data) };
+}
+
+function detectImageMimeType(data: Uint8Array): string {
+  if (startsWith(data, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png";
+  if (startsWith(data, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  if (ascii(data, 0, 4) === "GIF8") return "image/gif";
+  if (ascii(data, 0, 4) === "RIFF" && ascii(data, 8, 4) === "WEBP") return "image/webp";
+  return "image/png";
+}
+
+function startsWith(data: Uint8Array, prefix: number[]): boolean {
+  return prefix.every((value, index) => data[index] === value);
+}
+
+function ascii(data: Uint8Array, offset: number, length: number): string {
+  return String.fromCharCode(...data.slice(offset, offset + length));
+}

--- a/src/model-options.test.ts
+++ b/src/model-options.test.ts
@@ -24,7 +24,7 @@ const spec: ModelOptionSpec = {
 test("resolves picker options and applies them to a Fast request", () => {
   const options = resolveModelRequestOptions(
     spec,
-    { reasoningEffort: "adaptive", reasoningSummary: "detailed", webSearch: true },
+    { reasoningEffort: "adaptive", reasoningSummary: "detailed", webSearch: true, imageGeneration: true },
     { reasoningSummary: "concise" },
     "fast",
   );
@@ -34,6 +34,7 @@ test("resolves picker options and applies them to a Fast request", () => {
     reasoningEffort: "adaptive",
     reasoningSummary: "detailed",
     webSearch: true,
+    imageGeneration: true,
   });
   assert.deepEqual(applyModelRequestOptions({ model: "gpt-5.6-sol" }, options), {
     model: "gpt-5.6-sol",
@@ -66,7 +67,7 @@ test("falls back to live model defaults and reads legacy picker values", () => {
       { reasoningEffort: "adaptive", reasoningSummary: "model" },
       "normal",
     ),
-    { speedMode: "normal", reasoningEffort: "medium", reasoningSummary: "auto", webSearch: false },
+    { speedMode: "normal", reasoningEffort: "medium", reasoningSummary: "auto", webSearch: false, imageGeneration: false },
   );
   assert.equal(
     resolveModelRequestOptions(spec, { mode: "fast:adaptive" }, {}, "normal").reasoningEffort,
@@ -82,7 +83,7 @@ test("retains legacy workspace effort and speed fallbacks", () => {
       { reasoningEffort: "adaptive", speedMode: "fast", reasoningSummary: "model" },
       "normal",
     ),
-    { speedMode: "fast", reasoningEffort: "adaptive", reasoningSummary: "auto", webSearch: false },
+    { speedMode: "fast", reasoningEffort: "adaptive", reasoningSummary: "auto", webSearch: false, imageGeneration: false },
   );
   assert.equal(
     resolveModelRequestOptions({ ...spec, supportsFast: false }, undefined, { speedMode: "fast" }, "normal").speedMode,
@@ -100,6 +101,7 @@ test("builds picker controls from the live model metadata", () => {
     reasoningEffort: "adaptive",
     reasoningSummary: "concise",
     webSearch: false,
+    imageGeneration: false,
   });
 
   assert.deepEqual(schema.properties.reasoningEffort.enum, ["medium", "adaptive"]);
@@ -112,6 +114,10 @@ test("builds picker controls from the live model metadata", () => {
   assert.equal(schema.properties.webSearch.title, "Web Search");
   assert.equal(schema.properties.webSearch.default, false);
   assert.equal(schema.properties.webSearch.group, "navigation");
+  assert.equal(schema.properties.imageGeneration.type, "boolean");
+  assert.equal(schema.properties.imageGeneration.title, "Image Generation");
+  assert.equal(schema.properties.imageGeneration.default, false);
+  assert.equal(schema.properties.imageGeneration.group, "navigation");
   assert.deepEqual(schema.properties.speedMode.enum, ["normal", "fast"]);
   assert.deepEqual(schema.properties.speedMode.enumDescriptions, [
     "Standard speed and usage",
@@ -126,10 +132,12 @@ test("builds picker controls from the live model metadata", () => {
     reasoningEffort: "adaptive",
     reasoningSummary: "concise",
     webSearch: false,
+    imageGeneration: false,
   });
   assert.deepEqual(legacyFastDefaultSchema.properties.speedMode.enum, ["normal", "fast"]);
   assert.equal(legacyFastDefaultSchema.properties.speedMode.default, "fast");
   assert.equal(legacyFastDefaultSchema.properties.webSearch.default, false);
+  assert.equal(legacyFastDefaultSchema.properties.imageGeneration.default, false);
 
   const unsupported = buildModelConfigurationSchema({
     ...spec,

--- a/src/model-options.ts
+++ b/src/model-options.ts
@@ -27,6 +27,7 @@ export interface ModelRequestOptions {
   reasoningEffort: ReasoningEffort;
   reasoningSummary: ReasoningSummary;
   webSearch: boolean;
+  imageGeneration: boolean;
 }
 
 /**
@@ -90,6 +91,8 @@ export function resolveModelRequestOptions(
     ?? parseConfiguredSummary(stringOption(workspaceDefaults, "reasoningSummary"));
   const requestedWebSearch = booleanOption(requestConfiguration, "webSearch")
     ?? booleanOption(workspaceDefaults, "webSearch");
+  const requestedImageGeneration = booleanOption(requestConfiguration, "imageGeneration")
+    ?? booleanOption(workspaceDefaults, "imageGeneration");
   const requestedSpeed = parseConfiguredSpeed(stringOption(requestConfiguration, "speedMode"))
     ?? legacyMode?.speedMode
     ?? parseConfiguredSpeed(stringOption(workspaceDefaults, "speedMode"));
@@ -102,6 +105,7 @@ export function resolveModelRequestOptions(
       ? spec.defaultReasoningSummary
       : requestedSummary,
     webSearch: requestedWebSearch ?? false,
+    imageGeneration: requestedImageGeneration ?? false,
     speedMode: speedMode === "fast"
       ? "fast"
       : spec.supportsFast && requestedSpeed === "fast" ? "fast" : "normal",
@@ -155,6 +159,13 @@ export function buildModelConfigurationSchema(
         title: "Web Search",
         description: "Allow Codex to use OpenAI-hosted web search for this model.",
         default: defaults?.webSearch ?? false,
+        group: "navigation",
+      },
+      imageGeneration: {
+        type: "boolean",
+        title: "Image Generation",
+        description: "Allow Codex to use OpenAI-hosted image generation for this model.",
+        default: defaults?.imageGeneration ?? false,
         group: "navigation",
       },
       ...(exposesSpeedMode ? {

--- a/src/native-tools.test.ts
+++ b/src/native-tools.test.ts
@@ -3,9 +3,20 @@ import test from "node:test";
 import { buildNativeTools } from "./native-tools";
 
 test("keeps hosted web search disabled by default", () => {
-  assert.deepEqual(buildNativeTools({ webSearch: false }), []);
+  assert.deepEqual(buildNativeTools({ webSearch: false, imageGeneration: false }), []);
 });
 
 test("builds the Responses web-search descriptor when opted in", () => {
-  assert.deepEqual(buildNativeTools({ webSearch: true }), [{ type: "web_search" }]);
+  assert.deepEqual(buildNativeTools({ webSearch: true, imageGeneration: false }), [{ type: "web_search" }]);
+});
+
+test("builds the Responses image-generation descriptor when opted in", () => {
+  assert.deepEqual(buildNativeTools({ webSearch: false, imageGeneration: true }), [{ type: "image_generation" }]);
+});
+
+test("preserves the order of multiple hosted tools", () => {
+  assert.deepEqual(buildNativeTools({ webSearch: true, imageGeneration: true }), [
+    { type: "web_search" },
+    { type: "image_generation" },
+  ]);
 });

--- a/src/native-tools.ts
+++ b/src/native-tools.ts
@@ -3,6 +3,11 @@
 import type { ModelRequestOptions } from "./model-options";
 
 /** Builds the provider-owned native tool descriptors for one request. */
-export function buildNativeTools(options: Pick<ModelRequestOptions, "webSearch">): Record<string, unknown>[] {
-  return options.webSearch ? [{ type: "web_search" }] : [];
+export function buildNativeTools(
+  options: Pick<ModelRequestOptions, "webSearch" | "imageGeneration">,
+): Record<string, unknown>[] {
+  return [
+    ...(options.webSearch ? [{ type: "web_search" }] : []),
+    ...(options.imageGeneration ? [{ type: "image_generation" }] : []),
+  ];
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -17,6 +17,7 @@ import {
   parseCodexModelsPayload,
   type CodexModelMetadata,
 } from "./model-catalog";
+import { decodeGeneratedImage } from "./image-data";
 import { buildNativeTools } from "./native-tools";
 import { OpenAIOAuth } from "./oauth";
 import { buildPromptCacheRequestFields, createPromptCacheTransportHeaders } from "./prompt-cache";
@@ -197,7 +198,7 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     if (!response.body) throw new Error("OpenAI Codex returned an empty response stream");
 
     if (configuration().get("debugLogging", false)) {
-      this.output.appendLine(`[request] model=${model.rawModelId} speed=${requestOptions.speedMode} effort=${requestOptions.reasoningEffort} summary=${requestOptions.reasoningSummary} webSearch=${requestOptions.webSearch} initiator=${options.requestInitiator ?? "unknown"}`);
+      this.output.appendLine(`[request] model=${model.rawModelId} speed=${requestOptions.speedMode} effort=${requestOptions.reasoningEffort} summary=${requestOptions.reasoningSummary} webSearch=${requestOptions.webSearch} imageGeneration=${requestOptions.imageGeneration} initiator=${options.requestInitiator ?? "unknown"}`);
     }
     await consumeStream(response.body, progress, token, (usage) => this.captureRequestUsage(usage, model.rawModelId));
     if (Date.now() - this.lastQuotaFetchAt > 60_000) {
@@ -519,6 +520,17 @@ function reportEvent(event: CodexStreamEvent, progress: vscode.Progress<vscode.L
   }
   if (event.webSearchAnnotation) {
     reportDataPart(progress, "web-search-annotation", event.webSearchAnnotation);
+  }
+  if (event.imageGenerationPartial) {
+    const image = decodeGeneratedImage(event.imageGenerationPartial.result);
+    progress.report(vscode.LanguageModelDataPart.image(image.data, image.mimeType));
+  }
+  if (event.imageGenerationCall) {
+    if (event.imageGenerationCall.status === "failed") throw new Error("Codex image generation failed");
+    if (event.imageGenerationCall.result) {
+      const image = decodeGeneratedImage(event.imageGenerationCall.result);
+      progress.report(vscode.LanguageModelDataPart.image(image.data, image.mimeType));
+    }
   }
   if (event.usage) {
     const usage = toProviderUsagePayload(event.usage);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -521,10 +521,6 @@ function reportEvent(event: CodexStreamEvent, progress: vscode.Progress<vscode.L
   if (event.webSearchAnnotation) {
     reportDataPart(progress, "web-search-annotation", event.webSearchAnnotation);
   }
-  if (event.imageGenerationPartial) {
-    const image = decodeGeneratedImage(event.imageGenerationPartial.result);
-    progress.report(vscode.LanguageModelDataPart.image(image.data, image.mimeType));
-  }
   if (event.imageGenerationCall) {
     if (event.imageGenerationCall.status === "failed") throw new Error("Codex image generation failed");
     if (event.imageGenerationCall.result) {

--- a/src/sse.test.ts
+++ b/src/sse.test.ts
@@ -48,17 +48,15 @@ test("preserves hosted web-search calls and citations as data events", () => {
   ]);
 });
 
-test("parses streamed image-generation partials and final output", () => {
+test("parses the final image-generation output and suppresses completed duplicates", () => {
   const parser = new ResponsesStreamParser();
   const result = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64");
   const events = parser.push([
-    `data: ${JSON.stringify({ type: "response.image_generation_call.partial_image", partial_image_index: 0, partial_image_b64: result })}`,
     `data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "image_generation_call", id: "img1", status: "completed", result } })}`,
     `data: ${JSON.stringify({ type: "response.completed", response: { output: [{ type: "image_generation_call", id: "img1", status: "completed", result }], usage: { total_tokens: 12 } } })}`,
   ].join("\n\n") + "\n\n");
 
   assert.deepEqual(events, [
-    { imageGenerationPartial: { index: 0, result } },
     { imageGenerationCall: { id: "img1", status: "completed", result } },
     { usage: { total_tokens: 12 } },
   ]);

--- a/src/sse.test.ts
+++ b/src/sse.test.ts
@@ -48,6 +48,28 @@ test("preserves hosted web-search calls and citations as data events", () => {
   ]);
 });
 
+test("parses streamed image-generation partials and final output", () => {
+  const parser = new ResponsesStreamParser();
+  const result = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64");
+  const events = parser.push([
+    `data: ${JSON.stringify({ type: "response.image_generation_call.partial_image", partial_image_index: 0, partial_image_b64: result })}`,
+    `data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "image_generation_call", id: "img1", status: "completed", result } })}`,
+    `data: ${JSON.stringify({ type: "response.completed", response: { output: [{ type: "image_generation_call", id: "img1", status: "completed", result }], usage: { total_tokens: 12 } } })}`,
+  ].join("\n\n") + "\n\n");
+
+  assert.deepEqual(events, [
+    { imageGenerationPartial: { index: 0, result } },
+    { imageGenerationCall: { id: "img1", status: "completed", result } },
+    { usage: { total_tokens: 12 } },
+  ]);
+});
+
+test("preserves failed image-generation calls for provider error handling", () => {
+  const parser = new ResponsesStreamParser();
+  const events = parser.push('data: {"type":"response.output_item.done","item":{"type":"image_generation_call","id":"img1","status":"failed"}}\n\n');
+  assert.deepEqual(events, [{ imageGenerationCall: { id: "img1", status: "failed" } }]);
+});
+
 test("preserves encrypted reasoning for stateless follow-up requests", () => {
   const parser = new ResponsesStreamParser();
   const events = parser.push('data: {"type":"response.output_item.done","item":{"type":"reasoning","id":"r1","encrypted_content":"ciphertext"}}\n\n');

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -9,7 +9,6 @@ export interface CodexStreamEvent {
   toolCall?: { id: string; name: string; arguments: string };
   webSearchCall?: { id: string; status?: string; action?: Record<string, unknown> };
   webSearchAnnotation?: Record<string, unknown>;
-  imageGenerationPartial?: { index: number; result: string };
   imageGenerationCall?: { id: string; status?: string; result?: string };
   usage?: Record<string, unknown>;
   error?: string;
@@ -83,11 +82,6 @@ export class ResponsesStreamParser {
       const annotation = recordField(value, "annotation");
       return annotation ? [{ webSearchAnnotation: annotation }] : undefined;
     }
-    if (type === "response.image_generation_call.partial_image") {
-      const result = stringField(value, "partial_image_b64");
-      const index = numberField(value, "partial_image_index");
-      return result && index !== undefined ? [{ imageGenerationPartial: { index, result } }] : undefined;
-    }
     if (type === "response.output_item.done") {
       const item = recordField(value, "item");
       if (item?.type === "function_call") {
@@ -142,10 +136,6 @@ function recordField(value: Record<string, unknown>, key: string): Record<string
 
 function stringField(value: Record<string, unknown>, key: string): string | undefined {
   return typeof value[key] === "string" ? value[key] as string : undefined;
-}
-
-function numberField(value: Record<string, unknown>, key: string): number | undefined {
-  return typeof value[key] === "number" ? value[key] as number : undefined;
 }
 
 function imageGenerationEvent(

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -9,6 +9,8 @@ export interface CodexStreamEvent {
   toolCall?: { id: string; name: string; arguments: string };
   webSearchCall?: { id: string; status?: string; action?: Record<string, unknown> };
   webSearchAnnotation?: Record<string, unknown>;
+  imageGenerationPartial?: { index: number; result: string };
+  imageGenerationCall?: { id: string; status?: string; result?: string };
   usage?: Record<string, unknown>;
   error?: string;
 }
@@ -24,6 +26,7 @@ export interface CodexStreamEvent {
 export class ResponsesStreamParser {
   private buffer = "";
   private readonly toolArguments = new Map<string, string>();
+  private readonly imageGenerationCalls = new Set<string>();
 
   /**
    * Adds a transport chunk and returns every complete event it contains.
@@ -80,6 +83,11 @@ export class ResponsesStreamParser {
       const annotation = recordField(value, "annotation");
       return annotation ? [{ webSearchAnnotation: annotation }] : undefined;
     }
+    if (type === "response.image_generation_call.partial_image") {
+      const result = stringField(value, "partial_image_b64");
+      const index = numberField(value, "partial_image_index");
+      return result && index !== undefined ? [{ imageGenerationPartial: { index, result } }] : undefined;
+    }
     if (type === "response.output_item.done") {
       const item = recordField(value, "item");
       if (item?.type === "function_call") {
@@ -94,6 +102,10 @@ export class ResponsesStreamParser {
           action: recordField(item, "action"),
         } }];
       }
+      if (item?.type === "image_generation_call") {
+        const imageEvent = imageGenerationEvent(item, this.imageGenerationCalls);
+        return imageEvent ? [imageEvent] : undefined;
+      }
       if (item?.type === "reasoning") {
         const encrypted = stringField(item, "encrypted_content");
         if (encrypted) return [{ encryptedReasoning: { id: stringField(item, "id") ?? `reasoning-${Date.now()}`, data: encrypted } }];
@@ -101,8 +113,19 @@ export class ResponsesStreamParser {
     }
     if (type === "response.completed") {
       const response = recordField(value, "response");
+      const events: CodexStreamEvent[] = [];
+      const output = response?.output;
+      if (Array.isArray(output)) {
+        for (const item of output) {
+          if (item && typeof item === "object" && !Array.isArray(item)) {
+            const imageEvent = imageGenerationEvent(item as Record<string, unknown>, this.imageGenerationCalls);
+            if (imageEvent) events.push(imageEvent);
+          }
+        }
+      }
       const usage = recordField(response ?? {}, "usage");
-      return usage ? [{ usage }] : undefined;
+      if (usage) events.push({ usage });
+      return events.length ? events : undefined;
     }
     if (type === "error" || type === "response.failed") {
       const error = recordField(value, "error") ?? recordField(recordField(value, "response") ?? {}, "error");
@@ -119,4 +142,21 @@ function recordField(value: Record<string, unknown>, key: string): Record<string
 
 function stringField(value: Record<string, unknown>, key: string): string | undefined {
   return typeof value[key] === "string" ? value[key] as string : undefined;
+}
+
+function numberField(value: Record<string, unknown>, key: string): number | undefined {
+  return typeof value[key] === "number" ? value[key] as number : undefined;
+}
+
+function imageGenerationEvent(
+  item: Record<string, unknown>,
+  emitted: Set<string>,
+): CodexStreamEvent | undefined {
+  const id = stringField(item, "id") ?? `image-generation-${Date.now()}`;
+  const status = stringField(item, "status");
+  const result = stringField(item, "result");
+  if (!result && status !== "failed") return undefined;
+  if (emitted.has(id)) return undefined;
+  emitted.add(id);
+  return { imageGenerationCall: { id, status, ...(result ? { result } : {}) } };
 }


### PR DESCRIPTION
## Summary

- add a default-off per-model Image Generation control
- send the hosted Responses `image_generation` tool when enabled
- parse final image-generation output items with duplicate suppression
- decode generated image data and return it as VS Code `LanguageModelDataPart.image`
- add focused parser, option, descriptor, and image-format tests
- document the private-backend compatibility boundary and add a minor changeset

## Pullfrog follow-up

The optional partial-image path was removed after review. The request does not enable `partial_images`, and VS Code data parts are append-only, so the provider now emits only the completed image and avoids duplicate preview/final images.

## Validation

- `npm test` — 50 tests passed
- `npm run package` — VSIX packaging succeeded

## Compatibility note

The public Responses API documents the hosted tool contract, but this extension uses the private ChatGPT Codex OAuth endpoint. The remaining acceptance step is an authenticated VS Code Development Host smoke test against the signed-in account and selected model.

## Follow-up acceptance checks

- enable Image Generation in the Copilot model picker
- verify a generated image renders in chat
- verify a follow-up edit sends the image back as `input_image`
- verify unsupported backend/model responses fail cleanly