### PR TITLE
Add configurable Codex model catalog caching

### DIFF
--- a/.changeset/three-way-catalog-cache.md
+++ b/.changeset/three-way-catalog-cache.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": minor
+---
+
+Add configurable caching for the live Codex model catalog, with last-known-good model metadata retained when refreshes fail.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ selected in the model picker. Generated images are returned directly in the chat
 response; the backend must support the hosted Responses image-generation tool.
 
 - `openaiCodex.requestTimeoutSeconds`: total request timeout
+- `openaiCodex.catalogCacheMinutes`: how long the live model catalog is reused before refreshing
 - `openaiCodex.debugLogging`: request metadata only; prompts and tokens are never logged
 - `openaiCodex.showUsageStatusBar`: show or hide the Codex quota/token indicator
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -26,6 +26,10 @@ prettified display names, descriptions, context windows, capabilities, reasoning
 efforts, and Fast availability from the catalog response. Upstream hidden models are
 not registered.
 
+`openaiCodex.catalogCacheMinutes` controls how long the last successful catalog is
+reused before the next discovery request. If a refresh fails, the last usable catalog
+remains available.
+
 After sign-in, the **Codex** status-bar item shows ChatGPT subscription utilization for the primary and secondary quota windows. Click it to refresh quota, inspect reset times, or view exact input/output tokens from the most recent inference. Those normalized token counts are also reported to Copilot Chat so its context-window percentage reflects real usage.
 
 ## Browser callback problems

--- a/package.json
+++ b/package.json
@@ -122,6 +122,12 @@
           "minimum": 10,
           "description": "Maximum duration of a Codex request in seconds."
         },
+        "openaiCodex.catalogCacheMinutes": {
+          "type": "number",
+          "default": 5,
+          "minimum": 1,
+          "description": "How long the live Codex model catalog is reused before refreshing."
+        },
         "openaiCodex.debugLogging": {
           "type": "boolean",
           "default": false,

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -51,6 +51,7 @@ async function manage(
   else if (picked.action === "logs") output.show(true);
   else if (picked.action === "signout") {
     await oauth.signOut();
+    provider.clearModelCache();
     provider.clearUsage();
     usageStatus.hide();
     provider.fireDidChange();
@@ -70,6 +71,7 @@ async function browserSignIn(oauth: OpenAIOAuth, provider: OpenAICodexProvider, 
         try { await attempt?.completion; } finally { listener.dispose(); }
       },
     );
+    provider.clearModelCache();
     provider.fireDidChange();
     refreshUsageAfterAuth(provider, output, "post-sign-in");
     vscode.window.showInformationMessage("Signed in to Codex Bridge with ChatGPT.");
@@ -91,6 +93,7 @@ async function manualSignIn(oauth: OpenAIOAuth, provider: OpenAICodexProvider, o
     });
     if (!callback) return;
     await oauth.completeAuthorization(callback, flow);
+    provider.clearModelCache();
     provider.fireDidChange();
     refreshUsageAfterAuth(provider, output, "post-sign-in");
     vscode.window.showInformationMessage("Signed in to Codex Bridge with ChatGPT.");
@@ -108,6 +111,7 @@ async function importCodexSession(oauth: OpenAIOAuth, provider: OpenAICodexProvi
     );
     if (confirmed !== "Import session") return;
     const session = await oauth.importCodexCliSession();
+    provider.clearModelCache();
     provider.fireDidChange();
     refreshUsageAfterAuth(provider, output, "post-import");
     vscode.window.showInformationMessage(`Imported Codex CLI session${session.email ? ` for ${session.email}` : ""}.`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,8 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.workspace.onDidChangeConfiguration((event) => {
       if (event.affectsConfiguration("openaiCodex.reasoningSummary")
         || event.affectsConfiguration("openaiCodex.reasoningEffort")
-        || event.affectsConfiguration("openaiCodex.speedMode")) {
+        || event.affectsConfiguration("openaiCodex.speedMode")
+        || event.affectsConfiguration("openaiCodex.catalogCacheMinutes")) {
         provider.fireDidChange();
       }
       if (event.affectsConfiguration("openaiCodex.showUsageStatusBar")) updateUsageStatusVisibility(usageStatus);

--- a/src/models/catalog-cache.test.ts
+++ b/src/models/catalog-cache.test.ts
@@ -51,3 +51,16 @@ test("clearing the cache forces the next refresh", async () => {
 
   assert.equal(loads, 2);
 });
+
+test("does not publish a load that started before cache invalidation", async () => {
+  let resolveOld: ((value: string[]) => void) | undefined;
+  const cache = new CatalogCache<string[]>();
+  const oldLoad = cache.getOrRefresh(100_000, () => new Promise<string[]>((resolve) => {
+    resolveOld = resolve;
+  }));
+
+  cache.clear();
+  resolveOld!(["old-account"]);
+  await assert.rejects(oldLoad, /invalidated during refresh/);
+  assert.deepEqual(await cache.getOrRefresh(100_000, async () => ["new-account"]), ["new-account"]);
+});

--- a/src/models/catalog-cache.test.ts
+++ b/src/models/catalog-cache.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CatalogCache } from "./catalog-cache";
+
+test("reuses a fresh catalog without refreshing", async () => {
+  let now = 1_000;
+  let loads = 0;
+  const cache = new CatalogCache<string[]>(() => now);
+
+  assert.deepEqual(await cache.getOrRefresh(100, async () => { loads++; return ["first"]; }), ["first"]);
+  now += 50;
+  assert.deepEqual(await cache.getOrRefresh(100, async () => { loads++; return ["second"]; }), ["first"]);
+  assert.equal(loads, 1);
+});
+
+test("refreshes expired entries and preserves the last usable catalog on failure", async () => {
+  let now = 1_000;
+  const cache = new CatalogCache<string[]>(() => now);
+  await cache.getOrRefresh(100, async () => ["first"]);
+  now += 100;
+
+  assert.deepEqual(await cache.getOrRefresh(100, async () => { throw new Error("offline"); }), ["first"]);
+});
+
+test("does not turn cancellation into a successful cached response", async () => {
+  let now = 1_000;
+  const cache = new CatalogCache<string[]>(() => now);
+  await cache.getOrRefresh(100, async () => ["first"]);
+  now += 100;
+  const cancellation = new Error("cancelled");
+
+  await assert.rejects(
+    cache.getOrRefresh(100, async () => { throw cancellation; }, (error) => error === cancellation),
+    cancellation,
+  );
+});
+
+test("does not hide the first refresh failure", async () => {
+  const cache = new CatalogCache<string[]>();
+  const failure = new Error("unavailable");
+
+  await assert.rejects(cache.getOrRefresh(100, async () => { throw failure; }), failure);
+});
+
+test("clearing the cache forces the next refresh", async () => {
+  let loads = 0;
+  const cache = new CatalogCache<string[]>();
+  await cache.getOrRefresh(100_000, async () => { loads++; return ["first"]; });
+  cache.clear();
+  await cache.getOrRefresh(100_000, async () => { loads++; return ["second"]; });
+
+  assert.equal(loads, 2);
+});

--- a/src/models/catalog-cache.ts
+++ b/src/models/catalog-cache.ts
@@ -1,0 +1,30 @@
+/** Small in-memory cache policy for authenticated model catalogs. */
+
+export class CatalogCache<T> {
+  private value: T | undefined;
+  private refreshedAt = 0;
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  clear(): void {
+    this.value = undefined;
+    this.refreshedAt = 0;
+  }
+
+  async getOrRefresh(
+    maxAgeMs: number,
+    load: () => Promise<T>,
+    isCancellation: (error: unknown) => boolean = () => false,
+  ): Promise<T> {
+    if (this.value !== undefined && this.now() - this.refreshedAt < maxAgeMs) return this.value;
+    try {
+      const value = await load();
+      this.value = value;
+      this.refreshedAt = this.now();
+      return value;
+    } catch (error) {
+      if (this.value !== undefined && !isCancellation(error)) return this.value;
+      throw error;
+    }
+  }
+}

--- a/src/models/catalog-cache.ts
+++ b/src/models/catalog-cache.ts
@@ -3,10 +3,12 @@
 export class CatalogCache<T> {
   private value: T | undefined;
   private refreshedAt = 0;
+  private generation = 0;
 
   constructor(private readonly now: () => number = Date.now) {}
 
   clear(): void {
+    this.generation += 1;
     this.value = undefined;
     this.refreshedAt = 0;
   }
@@ -16,13 +18,16 @@ export class CatalogCache<T> {
     load: () => Promise<T>,
     isCancellation: (error: unknown) => boolean = () => false,
   ): Promise<T> {
+    const generation = this.generation;
     if (this.value !== undefined && this.now() - this.refreshedAt < maxAgeMs) return this.value;
     try {
       const value = await load();
+      if (this.generation !== generation) throw new Error("Catalog cache was invalidated during refresh");
       this.value = value;
       this.refreshedAt = this.now();
       return value;
     } catch (error) {
+      if (this.generation !== generation) throw error;
       if (this.value !== undefined && !isCancellation(error)) return this.value;
       throw error;
     }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -59,6 +59,8 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
   readonly onDidChangeUsage = this.usageEmitter.event;
   private usage: CodexUsageSnapshot;
   private lastQuotaFetchAt = 0;
+  private lastModelRefreshAt = 0;
+  private cachedModels: CodexModelMetadata[] | undefined;
   private readonly transport: CodexTransport;
 
   constructor(
@@ -147,7 +149,6 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     token: vscode.CancellationToken,
   ): Promise<CodexModel[]> {
     if (token.isCancellationRequested) return [];
-    // Each refresh can change capabilities, defaults, and the available Speed Mode toggle.
     const models = expandCodexModelVariants(await this.fetchModels(token));
     return models.map((model) => {
       const optionSpec = modelOptionSpec(model);
@@ -237,9 +238,21 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
   }
 
   private async fetchModels(cancellation: vscode.CancellationToken): Promise<CodexModelMetadata[]> {
+    const maxAge = Math.max(1, configuration().get("catalogCacheMinutes", 5)) * 60_000;
+    if (this.cachedModels && Date.now() - this.lastModelRefreshAt < maxAge) return this.cachedModels;
     const response = await this.transport.sendModels(cancellation);
-    if (!response.ok) throw await responseError("Unable to load OpenAI Codex models", response);
-    return parseCodexModelsPayload(await response.json());
+    if (!response.ok) {
+      if (this.cachedModels) return this.cachedModels;
+      throw await responseError("Unable to load OpenAI Codex models", response);
+    }
+    const models = parseCodexModelsPayload(await response.json());
+    if (!models.length) {
+      if (this.cachedModels) return this.cachedModels;
+      throw new Error("OpenAI Codex returned no usable models");
+    }
+    this.cachedModels = models;
+    this.lastModelRefreshAt = Date.now();
+    return models;
   }
 
   private captureRequestUsage(raw: Record<string, unknown>, modelId: string): void {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -31,6 +31,7 @@ import {
   type CodexUsageSnapshot,
 } from "./usage/domain";
 import { CodexTransport } from "./transport/client";
+import { CatalogCache } from "./models/catalog-cache";
 
 /** Live model information registered with VS Code Chat. */
 export interface CodexModel extends vscode.LanguageModelChatInformation {
@@ -59,12 +60,12 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
   readonly onDidChangeUsage = this.usageEmitter.event;
   private usage: CodexUsageSnapshot;
   private lastQuotaFetchAt = 0;
-  private lastModelRefreshAt = 0;
-  private cachedModels: CodexModelMetadata[] | undefined;
+  private readonly modelCache = new CatalogCache<CodexModelMetadata[]>();
+  private modelCacheAccount: string | undefined;
   private readonly transport: CodexTransport;
 
   constructor(
-    oauth: OpenAIOAuth,
+    private readonly oauth: OpenAIOAuth,
     private readonly output: vscode.OutputChannel,
     userAgent: string,
     initialUsage: CodexUsageSnapshot = {},
@@ -81,6 +82,11 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
 
   fireDidChange(): void {
     this.changeEmitter.fire();
+  }
+
+  clearModelCache(): void {
+    this.modelCache.clear();
+    this.modelCacheAccount = undefined;
   }
 
   getUsageSnapshot(): CodexUsageSnapshot {
@@ -239,19 +245,17 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
 
   private async fetchModels(cancellation: vscode.CancellationToken): Promise<CodexModelMetadata[]> {
     const maxAge = Math.max(1, configuration().get("catalogCacheMinutes", 5)) * 60_000;
-    if (this.cachedModels && Date.now() - this.lastModelRefreshAt < maxAge) return this.cachedModels;
-    const response = await this.transport.sendModels(cancellation);
-    if (!response.ok) {
-      if (this.cachedModels) return this.cachedModels;
-      throw await responseError("Unable to load OpenAI Codex models", response);
-    }
-    const models = parseCodexModelsPayload(await response.json());
-    if (!models.length) {
-      if (this.cachedModels) return this.cachedModels;
-      throw new Error("OpenAI Codex returned no usable models");
-    }
-    this.cachedModels = models;
-    this.lastModelRefreshAt = Date.now();
+    const session = await this.oauth.sessionInfo();
+    const account = session?.accountId ?? session?.email;
+    if (!account || account !== this.modelCacheAccount) this.clearModelCache();
+    const models = await this.modelCache.getOrRefresh(maxAge, async () => {
+      const response = await this.transport.sendModels(cancellation);
+      if (!response.ok) throw await responseError("Unable to load OpenAI Codex models", response);
+      const parsed = parseCodexModelsPayload(await response.json());
+      if (!parsed.length) throw new Error("OpenAI Codex returned no usable models");
+      return parsed;
+    }, () => cancellation.isCancellationRequested);
+    this.modelCacheAccount = account;
     return models;
   }
 


### PR DESCRIPTION
## Summary

- Add a configurable five-minute freshness window for live Codex model metadata.
- Retain the last usable catalog when a refresh fails.
- Document the setting and add a Changeset.

## Validation

- `npm run check`
- `npm run package`