### PR TITLE
Align provider parity for v0.9.0

### DIFF
--- a/.changeset/align-provider-shell.md
+++ b/.changeset/align-provider-shell.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": minor
+---
+
+Add an explicit model refresh command, initialize the usage indicator consistently, and redact account identity from diagnostics.

--- a/.changeset/enrich-models-dev.md
+++ b/.changeset/enrich-models-dev.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": patch
+---
+
+Enrich the authoritative live Codex model directory with a persisted, stale-while-revalidate models.dev metadata snapshot.

--- a/.changeset/sync-reasoning-defaults.md
+++ b/.changeset/sync-reasoning-defaults.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": patch
+---
+
+Default ordered reasoning controls to High when supported while retaining the live model's supported levels.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - `src/provider.ts`: VS Code chat-provider integration and Responses API translation.
 - `src/transport/responses.ts`: incremental SSE parsing into text, reasoning, tool-call, and usage events.
 - `src/models/options.ts`: per-model speed/reasoning capabilities and request options.
+- `src/models/metadata.ts`: persisted models.dev enrichment for fields omitted by the live model directory.
 - `src/usage/`: quota parsing, local usage tracking, and display formatting.
 - `src/transport/protocol.ts`: shared endpoints and request identity constants.
 - Tests are colocated as `src/**/*.test.ts`; `out/` and `*.vsix` are generated artifacts.

--- a/README.md
+++ b/README.md
@@ -13,110 +13,38 @@
   <a href="https://github.com/grikomsn/openai-oauth-copilot-chat/blob/main/LICENSE"><img src="https://img.shields.io/github/license/grikomsn/openai-oauth-copilot-chat?style=flat-square" alt="MIT license"></a>
 </p>
 
-This extension is a native VS Code `LanguageModelChatProvider`. It handles OpenAI OAuth locally, streams ChatGPT Codex responses into Copilot Chat, and keeps tokens in VS Code Secret Storage.
+This native VS Code `LanguageModelChatProvider` handles OpenAI OAuth locally and streams ChatGPT Codex responses into Copilot Chat without a local proxy.
 
-## Features
+## Highlights
 
-- ChatGPT OAuth with PKCE and automatic access-token refresh
-- Models discovered from the live Codex catalog for the signed-in ChatGPT account
-- Streaming responses, reasoning summaries, images, and tool calling
-- Per-model reasoning effort, opt-in Web Search, Image Generation, and Speed Mode controls
-- Native Copilot context-window accounting from Codex inference token usage
-- Automatic OpenAI prompt-cache reuse for eligible prefixes across normal chat turns and agent tool loops
-- Status-bar indicator for five-hour/weekly ChatGPT Codex quota and locally tracked tokens
-- Browser callback, manual callback, and optional Codex CLI session import
-- Connection test and privacy-safe diagnostics commands
-
-The model picker follows the live Codex catalog instead of a list bundled with the
-extension. Display names, descriptions, context windows, image/tool capabilities,
-reasoning efforts, and Fast availability are derived from the signed-in account's
-catalog response. Models that advertise the `fast` additional speed tier expose a native
-**Speed Mode** control on their normal model entry.
-Every model also exposes an opt-in **Web Search** control beside its reasoning
-controls. It is disabled by default; when enabled, the request includes the
-Codex Responses API's hosted `web_search` tool and preserves streamed search
-annotations as provider data.
-The **Image Generation** control is also disabled by default; when enabled, the
-request includes the hosted `image_generation` tool and streams generated image
-data back into Copilot Chat. Availability depends on the signed-in Codex backend
-and selected model accepting that hosted tool.
-
-Context limits follow Codex's own runtime policy: the catalog's effective-window
-percentage defines the usable hard window, while its auto-compaction threshold defines
-the input budget. The remaining headroom is reported to VS Code as the output budget so
-Copilot Chat displays the same total context limit instead of adding an unrelated output
-allowance.
-
-## Requirements
-
-- VS Code 1.125 or newer
-- GitHub Copilot Chat installed and enabled
-- A ChatGPT account with Codex access (typically Plus or Pro)
+- ChatGPT OAuth with PKCE, automatic refresh, and VS Code Secret Storage
+- Live Codex model discovery with six-hour persisted models.dev enrichment
+- Streaming text, reasoning summaries, images, and agent-mode tool calls
+- Per-model reasoning effort, summary, Speed Mode, Web Search, and Image Generation controls
+- Codex-aware context accounting and prompt-cache reuse
+- Status-bar quota and local inference-token tracking
+- Browser, manual-callback, and optional Codex CLI session sign-in paths
+- Connection testing and secret-safe diagnostics
 
 ## Quick start
 
 1. Install [Codex Bridge for Copilot Chat](https://marketplace.visualstudio.com/items?itemName=grikomsn.openai-oauth-copilot-chat). You need VS Code 1.125 or newer, GitHub Copilot Chat, and a ChatGPT account with Codex access.
-2. Run **Codex Bridge: Manage Connection** from the Command Palette.
-3. Choose **Sign in with ChatGPT** and complete the browser flow.
-4. In Copilot Chat, open the model picker, choose **Manage Models**, enable **Codex Bridge**, and select a Codex model.
+2. Run **Codex Bridge: Manage Connection** and complete **Sign in with ChatGPT**. Use manual sign-in if local port `1455` is unavailable.
+3. Open Copilot Chat, select **Manage Models**, enable **Codex Bridge**, and choose a Codex model.
 
-Model names and descriptions come from the live catalog, with dashes in display labels
-formatted as spaces. Each model exposes native Copilot Chat controls for the advertised
-reasoning effort and, when supported, Speed Mode, so you can switch to the Fast service
-tier without adding a second model entry.
-
-If another process uses local port `1455`, choose **Sign in manually**. If the Codex CLI is already signed in, **Import Codex CLI Session** can copy its OAuth session from `~/.codex/auth.json` into VS Code Secret Storage.
-
-## Commands
-
-| Command                                                   | Purpose                                                      |
-| --------------------------------------------------------- | ------------------------------------------------------------ |
-| Codex Bridge: Manage Connection                           | Sign in, test, inspect logs, or sign out                     |
-| Codex Bridge: Sign In with ChatGPT                        | Start the local browser OAuth flow                           |
-| Codex Bridge: Sign In Manually                            | Paste a callback URL when port 1455 is unavailable           |
-| Codex Bridge: Import Codex CLI Session (Advanced)         | Copy an existing local Codex CLI login after a warning       |
-| Codex Bridge: Test Connection                             | Send a small live request to the Codex backend               |
-| Codex Bridge: Show Usage                                  | Refresh and inspect subscription quota, reset credits, and inference tokens |
-| Codex Bridge: Show Diagnostics                            | Show session presence and registered models without secrets  |
-
-## Settings
-
-- `openaiCodex.reasoningSummary`: workspace default for reasoning summaries; choose `auto`, `concise`, `detailed`, or `none`, while `model` follows the live catalog default
-- Legacy `openaiCodex.speedMode` and `openaiCodex.reasoningEffort` settings remain supported as workspace fallbacks for existing configurations. Prefer the live model picker for new selections.
-
-Each model defaults to the catalog's `default_reasoning_level` and exposes only the
-reasoning efforts advertised by that catalog. Fast processing can be selected through
-the model's native **Speed Mode** control; it uses more account capacity.
-Models that accept `reasoning.summary` also expose a per-model summary control; that
-selection overrides the workspace default.
-**Web Search** is an independent per-model toggle and remains disabled unless selected
-in the model picker.
-**Image Generation** is an independent per-model toggle and remains disabled unless
-selected in the model picker. Generated images are returned directly in the chat
-response; the backend must support the hosted Responses image-generation tool.
-
-- `openaiCodex.requestTimeoutSeconds`: total request timeout
-- `openaiCodex.catalogCacheMinutes`: how long the live model catalog is reused before refreshing
-- `openaiCodex.debugLogging`: request metadata only; prompts and tokens are never logged
-- `openaiCodex.showUsageStatusBar`: show or hide the Codex quota/token indicator
-
-The status bar reads the same ChatGPT Codex quota endpoint used by Codex CLI and shows the primary and secondary utilization windows. Click it for reset times, available banked reset credits when the account exposes them, the last inference token count, and cumulative tokens tracked by this extension on the current device. A banked reset applies to both the 5-hour and weekly windows; redeeming one requires explicit confirmation.
+The authenticated Codex catalog remains authoritative. Composer controls override workspace defaults; reasoning defaults to High when supported, while hosted Web Search and Image Generation remain off until enabled. Click the Codex status-bar item to inspect five-hour and weekly quota, reset timing, and tokens observed by this extension.
 
 ## Documentation
 
-- [Setup, settings, and troubleshooting](https://github.com/grikomsn/openai-oauth-copilot-chat/blob/main/docs/setup.md)
+- [Setup, commands, settings, and troubleshooting](https://github.com/grikomsn/openai-oauth-copilot-chat/blob/main/docs/setup.md)
 - [OAuth and security](https://github.com/grikomsn/openai-oauth-copilot-chat/blob/main/docs/security.md)
 - [Development and releases](https://github.com/grikomsn/openai-oauth-copilot-chat/blob/main/docs/development.md)
 
 ## Related projects
 
-- [Grok for GitHub Copilot Chat](https://github.com/grikomsn/grok-copilot-chat) — Use xAI Grok models directly from the GitHub Copilot Chat model picker in Visual Studio Code.
-- [Poolside for GitHub Copilot Chat](https://github.com/grikomsn/poolside-copilot-chat) — Use hosted Poolside coding models directly from the GitHub Copilot Chat model picker in Visual Studio Code.
-
-## Privacy and status
-
-OAuth tokens are stored through VS Code Secret Storage and are sent only to OpenAI authentication and ChatGPT Codex endpoints. This is an independent community extension, not an official OpenAI or GitHub product. The ChatGPT Codex backend is not a public compatibility API and can change; see [docs/security.md](docs/security.md).
-
-Requests identify this extension as `openai-oauth-copilot-chat`; they do not claim to originate from the official Codex CLI or VS Code extension. The shared OAuth client and ChatGPT backend are undocumented integration surfaces, so OpenAI may change or revoke compatibility without notice.
+- [Grok for GitHub Copilot Chat](https://github.com/grikomsn/grok-copilot-chat)
+- [Ollama Cloud for GitHub Copilot Chat](https://github.com/grikomsn/ollama-cloud-copilot-chat)
+- [OpenCode for Copilot Chat](https://github.com/grikomsn/opencode-copilot-chat)
+- [Poolside for GitHub Copilot Chat](https://github.com/grikomsn/poolside-copilot-chat)
 
 Unofficial project; not affiliated with OpenAI, GitHub, or Microsoft. The ChatGPT Codex backend is not a public compatibility API and can change. Licensed under [MIT](LICENSE).

--- a/docs/security.md
+++ b/docs/security.md
@@ -4,7 +4,7 @@
 
 - OAuth access and refresh tokens are stored with VS Code Secret Storage.
 - Tokens and prompts are never written to the output channel.
-- Diagnostics report only whether a session exists, the account email when present, and public model metadata.
+- Diagnostics report only whether a session exists and public model metadata; account identity is redacted.
 - Codex CLI import reads only `~/.codex/auth.json` after the user explicitly runs the advanced import command and confirms the credential-copy warning.
 
 ## Network destinations
@@ -13,6 +13,7 @@
 - `https://auth.openai.com/oauth/token`
 - `https://chatgpt.com/backend-api/codex/responses`
 - `https://chatgpt.com/backend-api/wham/usage`
+- `https://models.dev/api.json` for public model metadata enrichment only
 
 Requests use the independent originator `openai-oauth-copilot-chat` and a matching user agent. They do not identify as the official Codex CLI or OpenAI VS Code extension.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,7 +6,9 @@ Run `code --install-extension openai-oauth-copilot-chat-0.1.0.vsix`, then reload
 
 Use **Codex Bridge: Manage Connection** to authenticate. After sign-in, open Copilot Chat's model picker and enable a model under **Manage Models → Codex Bridge**.
 
-Each model exposes the reasoning efforts advertised by the live Codex catalog. Models
+Each model exposes the reasoning efforts advertised by the live Codex catalog. Ordered
+effort controls default to High when the model supports it; otherwise the catalog default
+is retained. Models
 that advertise the `fast` additional speed tier expose a native **Speed Mode** control
 with Normal and Fast choices. Selecting Fast requests faster processing with increased
 account usage without adding a separate Fast model entry.
@@ -29,6 +31,10 @@ not registered.
 `openaiCodex.catalogCacheMinutes` controls how long the last successful catalog is
 reused before the next discovery request. If a refresh fails, the last usable catalog
 remains available.
+
+The live Codex directory remains authoritative for availability, limits, capabilities,
+and reasoning levels. The extension uses a six-hour, stale-while-revalidate models.dev
+snapshot in VS Code `globalState` only to fill metadata omitted by the live directory.
 
 After sign-in, the **Codex** status-bar item shows ChatGPT subscription utilization for the primary and secondary quota windows. Click it to refresh quota, inspect reset times, or view exact input/output tokens from the most recent inference. Those normalized token counts are also reported to Copilot Chat so its context-window percentage reflects real usage.
 

--- a/package.json
+++ b/package.json
@@ -53,10 +53,14 @@
         "command": "openaiCodex.importCodexSession",
         "title": "Codex Bridge: Import Codex CLI Session (Advanced)"
       },
-      {
-        "command": "openaiCodex.testConnection",
-        "title": "Codex Bridge: Test Connection"
-      },
+    {
+      "command": "openaiCodex.testConnection",
+      "title": "Codex Bridge: Test Connection"
+    },
+    {
+      "command": "openaiCodex.refreshModels",
+      "title": "Codex Bridge: Refresh Models"
+    },
       {
         "command": "openaiCodex.showUsage",
         "title": "Codex Bridge: Show Usage"

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -19,6 +19,7 @@ export function registerCodexCommands(
     vscode.commands.registerCommand("openaiCodex.signInManual", () => manualSignIn(oauth, provider, output)),
     vscode.commands.registerCommand("openaiCodex.importCodexSession", () => importCodexSession(oauth, provider, output)),
     vscode.commands.registerCommand("openaiCodex.testConnection", () => testConnection(provider, output)),
+    vscode.commands.registerCommand("openaiCodex.refreshModels", () => refreshModels(provider, output)),
     vscode.commands.registerCommand("openaiCodex.showUsage", () => showUsage(provider, output)),
     vscode.commands.registerCommand("openaiCodex.diagnostics", () => diagnostics(oauth, output)),
   ];
@@ -34,6 +35,7 @@ async function manage(
   const picked = await vscode.window.showQuickPick(session ? [
     { label: "$(pulse) Show Codex usage", action: "usage" },
     { label: "$(check) Test Codex connection", action: "test" },
+    { label: "$(refresh) Refresh Codex models", action: "refresh" },
     { label: "$(output) Show Codex Bridge logs", action: "logs" },
     { label: "$(sign-out) Sign out of Codex Bridge", action: "signout" },
   ] : [
@@ -48,6 +50,7 @@ async function manage(
   else if (picked.action === "import") await importCodexSession(oauth, provider, output);
   else if (picked.action === "usage") await showUsage(provider, output);
   else if (picked.action === "test") await testConnection(provider, output);
+  else if (picked.action === "refresh") await refreshModels(provider, output);
   else if (picked.action === "logs") output.show(true);
   else if (picked.action === "signout") {
     await oauth.signOut();
@@ -133,6 +136,18 @@ async function testConnection(provider: OpenAICodexProvider, output: vscode.Outp
   }
 }
 
+async function refreshModels(provider: OpenAICodexProvider, output: vscode.OutputChannel): Promise<void> {
+  try {
+    const count = await vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Window, title: "Refreshing Codex models…" },
+      () => provider.refreshModels(),
+    );
+    vscode.window.showInformationMessage(`Refreshed ${count} Codex models.`);
+  } catch (error) {
+    showError("Codex model refresh failed", error, output);
+  }
+}
+
 async function showUsage(provider: OpenAICodexProvider, output: vscode.OutputChannel): Promise<void> {
   let snapshot = provider.getUsageSnapshot();
   try {
@@ -206,7 +221,7 @@ async function diagnostics(oauth: OpenAIOAuth, output: vscode.OutputChannel): Pr
   const session = await oauth.sessionInfo();
   const content = [
     `# ${EXTENSION_DISPLAY_NAME} diagnostics`, "", `- VS Code: ${vscode.version}`,
-    `- OAuth session: ${session ? "present" : "missing"}`, `- Account: ${session?.email ?? "unknown"}`,
+    `- OAuth session: ${session ? "present" : "missing"}`, `- Account identity: ${session ? "redacted" : "unavailable"}`,
     `- Registered models: ${models.length}`, "", ...models.map((model) => `- ${model.id} (${model.maxInputTokens} input tokens)`),
   ].join("\n");
   output.appendLine(`[diagnostics] session=${Boolean(session)} models=${models.length}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,11 +18,13 @@ export function activate(context: vscode.ExtensionContext): void {
     output,
     extensionUserAgent(version, vscode.version),
     context.globalState.get<CodexUsageSnapshot>(USAGE_STATE_KEY) ?? {},
+    context.globalState,
   );
   const usageStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 91);
   usageStatus.name = "Codex Bridge usage";
   usageStatus.command = "openaiCodex.showUsage";
   renderUsageStatus(usageStatus, provider.getUsageSnapshot());
+  updateUsageStatusVisibility(usageStatus);
   context.subscriptions.push(
     output,
     usageStatus,

--- a/src/models/catalog.test.ts
+++ b/src/models/catalog.test.ts
@@ -155,12 +155,13 @@ test("keeps live Codex metadata authoritative and fills absent models.dev fields
     name: "Metadata Name",
     description: "Metadata description",
     contextLength: 200_000,
+    maxInputTokens: 175_000,
     maxOutputTokens: 20_000,
   });
   assert.deepEqual({ name: missing.name, description: missing.description, input: missing.input, output: missing.output }, {
     name: "Metadata Name",
     description: "Metadata description",
-    input: 180_000,
+    input: 175_000,
     output: 20_000,
   });
 });

--- a/src/models/catalog.test.ts
+++ b/src/models/catalog.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { expandCodexModelVariants, formatCodexDisplayName, parseCodexModelsPayload } from "./catalog";
+import { enrichCodexModel, expandCodexModelVariants, formatCodexDisplayName, parseCodexModelsPayload } from "./catalog";
 
 test("maps the visible remote catalog metadata", () => {
   const models = parseCodexModelsPayload({
@@ -132,6 +132,37 @@ test("keeps Fast-capable models in one picker entry", () => {
 test("prettifies catalog labels without replacing the product name", () => {
   assert.equal(formatCodexDisplayName("GPT-5.6-Luna"), "GPT 5.6 Luna");
   assert.equal(formatCodexDisplayName("Codex--Review"), "Codex Review");
+});
+
+test("keeps live Codex metadata authoritative and fills absent models.dev fields", () => {
+  const [live] = parseCodexModelsPayload({ models: [remoteModel()] });
+  const enriched = enrichCodexModel(live, {
+    id: live.id,
+    name: "Metadata Name",
+    description: "Metadata description",
+    contextLength: 999_999,
+    maxOutputTokens: 99_999,
+    releaseDate: "2026-01-01",
+  });
+  assert.equal(enriched.name, "GPT Test");
+  assert.equal(enriched.description, "Test model.");
+  assert.equal(enriched.input, live.input);
+  assert.equal(enriched.output, live.output);
+  assert.equal(enriched.releaseDate, "2026-01-01");
+
+  const missing = enrichCodexModel({ ...live, name: "", description: "", input: 0, output: 0 }, {
+    id: live.id,
+    name: "Metadata Name",
+    description: "Metadata description",
+    contextLength: 200_000,
+    maxOutputTokens: 20_000,
+  });
+  assert.deepEqual({ name: missing.name, description: missing.description, input: missing.input, output: missing.output }, {
+    name: "Metadata Name",
+    description: "Metadata description",
+    input: 180_000,
+    output: 20_000,
+  });
 });
 
 test("maps default and advertised Codex context limits", () => {

--- a/src/models/catalog.ts
+++ b/src/models/catalog.ts
@@ -1,5 +1,7 @@
 /** Model-directory types and normalization for the live Codex picker. */
 
+import type { ModelsDevModelMetadata } from "./metadata";
+
 /** Processing speed requested for a model. */
 export type SpeedMode = "normal" | "fast";
 /** A model-advertised reasoning effort. */
@@ -33,6 +35,8 @@ export interface CodexModelMetadata {
   supportsFast: boolean;
   fastDescription?: string;
   priority: number;
+  releaseDate?: string;
+  lastUpdated?: string;
 }
 
 /** A picker-ready model entry, including its selected speed mode. */
@@ -137,6 +141,22 @@ export function expandCodexModelVariants(models: readonly CodexModelMetadata[]):
  */
 export function formatCodexDisplayName(displayName: string): string {
   return displayName.replaceAll("-", " ").replace(/\s+/g, " ").trim();
+}
+
+export function enrichCodexModel(model: CodexModelMetadata, metadata: ModelsDevModelMetadata | undefined): CodexModelMetadata {
+  if (!metadata) return model;
+  const contextWindow = metadata.contextLength;
+  const output = model.output > 0 ? model.output : Math.min(metadata.maxOutputTokens ?? 0, contextWindow ?? Number.MAX_SAFE_INTEGER);
+  const input = model.input > 0 ? model.input : Math.max(0, (contextWindow ?? 0) - output);
+  return {
+    ...model,
+    name: model.name || metadata.name || model.id,
+    description: model.description || metadata.description || "",
+    input,
+    output,
+    releaseDate: metadata.releaseDate,
+    lastUpdated: metadata.lastUpdated,
+  };
 }
 
 function parseModel(model: RemoteCodexModel): CodexModelMetadata | undefined {

--- a/src/models/catalog.ts
+++ b/src/models/catalog.ts
@@ -147,7 +147,9 @@ export function enrichCodexModel(model: CodexModelMetadata, metadata: ModelsDevM
   if (!metadata) return model;
   const contextWindow = metadata.contextLength;
   const output = model.output > 0 ? model.output : Math.min(metadata.maxOutputTokens ?? 0, contextWindow ?? Number.MAX_SAFE_INTEGER);
-  const input = model.input > 0 ? model.input : Math.max(0, (contextWindow ?? 0) - output);
+  const input = model.input > 0
+    ? model.input
+    : metadata.maxInputTokens ?? Math.max(0, (contextWindow ?? 0) - output);
   return {
     ...model,
     name: model.name || metadata.name || model.id,

--- a/src/models/metadata.test.ts
+++ b/src/models/metadata.test.ts
@@ -23,15 +23,17 @@ const payload = { openai: { models: { "gpt-test": {
   reasoning_options: [{ type: "effort", values: ["low", "high"] }],
   tool_call: true,
   modalities: { input: ["text", "image"] },
-  limit: { context: 200_000, output: 20_000 },
+  limit: { context: 200_000, input: 175_000, output: 20_000 },
 } } } };
 
 test("normalizes the OpenAI models.dev provider", () => {
   const snapshot = normalizeModelsDevSnapshot(payload, 123);
   assert.equal(snapshot.models["gpt-test"]?.contextLength, 200_000);
+  assert.equal(snapshot.models["gpt-test"]?.maxInputTokens, 175_000);
   assert.equal(snapshot.models["gpt-test"]?.imageInput, true);
   assert.deepEqual(snapshot.models["gpt-test"]?.reasoningOptions, ["low", "high"]);
   assert.equal(parseCachedModelsDevSnapshot(snapshot)?.models["gpt-test"]?.toolCalling, true);
+  assert.equal(parseCachedModelsDevSnapshot(snapshot)?.models["gpt-test"]?.maxInputTokens, 175_000);
   assert.equal(parseCachedModelsDevSnapshot({ fetchedAt: -1, models: {} }), undefined);
 });
 

--- a/src/models/metadata.test.ts
+++ b/src/models/metadata.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MODELS_DEV_API_URL,
+  MODELS_DEV_CACHE_KEY,
+  MODELS_DEV_CACHE_TTL_MS,
+  ModelsDevMetadata,
+  normalizeModelsDevSnapshot,
+  parseCachedModelsDevSnapshot,
+  type MetadataCache,
+} from "./metadata";
+
+class MemoryCache implements MetadataCache {
+  readonly values = new Map<string, unknown>();
+  get<T>(key: string): T | undefined { return this.values.get(key) as T | undefined; }
+  async update(key: string, value: unknown): Promise<void> { this.values.set(key, value); }
+}
+
+const payload = { openai: { models: { "gpt-test": {
+  name: "GPT Test",
+  family: "gpt",
+  reasoning: true,
+  reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+  tool_call: true,
+  modalities: { input: ["text", "image"] },
+  limit: { context: 200_000, output: 20_000 },
+} } } };
+
+test("normalizes the OpenAI models.dev provider", () => {
+  const snapshot = normalizeModelsDevSnapshot(payload, 123);
+  assert.equal(snapshot.models["gpt-test"]?.contextLength, 200_000);
+  assert.equal(snapshot.models["gpt-test"]?.imageInput, true);
+  assert.deepEqual(snapshot.models["gpt-test"]?.reasoningOptions, ["low", "high"]);
+  assert.equal(parseCachedModelsDevSnapshot(snapshot)?.models["gpt-test"]?.toolCalling, true);
+  assert.equal(parseCachedModelsDevSnapshot({ fetchedAt: -1, models: {} }), undefined);
+});
+
+test("persists, reuses, and refreshes a models.dev snapshot", async () => {
+  const cache = new MemoryCache();
+  let now = 1000;
+  let calls = 0;
+  const metadata = new ModelsDevMetadata(cache, async (input) => {
+    calls += 1;
+    assert.equal(String(input), MODELS_DEV_API_URL);
+    return Response.json(payload);
+  }, () => now);
+  const first = await metadata.getOrRefresh();
+  assert.equal(await metadata.getOrRefresh(), first);
+  assert.equal(calls, 1);
+  assert.deepEqual(cache.values.get(MODELS_DEV_CACHE_KEY), first);
+  now += MODELS_DEV_CACHE_TTL_MS + 1;
+  assert.equal(await metadata.getOrRefresh(), first);
+  assert.equal(calls, 2);
+});
+
+test("falls back to stale persisted metadata when refresh fails", async () => {
+  const cache = new MemoryCache();
+  const stale = normalizeModelsDevSnapshot(payload, 1);
+  cache.values.set(MODELS_DEV_CACHE_KEY, stale);
+  const metadata = new ModelsDevMetadata(cache, async () => new Response("unavailable", { status: 503 }), () => 999999);
+  assert.equal((await metadata.refresh()).models["gpt-test"]?.name, "GPT Test");
+});

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -9,6 +9,7 @@ export interface ModelsDevModelMetadata {
   readonly description?: string;
   readonly family?: string;
   readonly contextLength?: number;
+  readonly maxInputTokens?: number;
   readonly maxOutputTokens?: number;
   readonly imageInput?: boolean;
   readonly toolCalling?: boolean;
@@ -119,6 +120,7 @@ function normalizeModel(key: string, value: unknown): ModelsDevModelMetadata | u
     description: optionalString(raw.description),
     family: optionalString(raw.family),
     contextLength: optionalTokenCount(limit?.context),
+    maxInputTokens: optionalTokenCount(limit?.input),
     maxOutputTokens: optionalTokenCount(limit?.output),
     imageInput: stringArray(modalities?.input).includes("image"),
     toolCalling: optionalBoolean(raw.tool_call),
@@ -133,7 +135,7 @@ function parseCachedModel(key: string, value: unknown): ModelsDevModelMetadata |
   const raw = asRecord(value);
   if (!raw) return undefined;
   const id = stringValue(raw.id) ?? key.trim();
-  if (!id || !validOptionalNumber(raw.contextLength) || !validOptionalNumber(raw.maxOutputTokens)) return undefined;
+  if (!id || !validOptionalNumber(raw.contextLength) || !validOptionalNumber(raw.maxInputTokens) || !validOptionalNumber(raw.maxOutputTokens)) return undefined;
   if (!validOptionalBoolean(raw.imageInput) || !validOptionalBoolean(raw.toolCalling) || !validOptionalBoolean(raw.reasoning)) return undefined;
   if (raw.reasoningOptions !== undefined && !isStringArray(raw.reasoningOptions)) return undefined;
   return {
@@ -142,6 +144,7 @@ function parseCachedModel(key: string, value: unknown): ModelsDevModelMetadata |
     description: optionalString(raw.description),
     family: optionalString(raw.family),
     contextLength: optionalTokenCount(raw.contextLength),
+    maxInputTokens: optionalTokenCount(raw.maxInputTokens),
     maxOutputTokens: optionalTokenCount(raw.maxOutputTokens),
     imageInput: optionalBoolean(raw.imageInput),
     toolCalling: optionalBoolean(raw.toolCalling),

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -1,0 +1,181 @@
+export const MODELS_DEV_API_URL = "https://models.dev/api.json";
+export const MODELS_DEV_CACHE_KEY = "openaiCodex.modelsDevMetadata.v1";
+export const MODELS_DEV_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const MODELS_DEV_TIMEOUT_MS = 15_000;
+
+export interface ModelsDevModelMetadata {
+  readonly id: string;
+  readonly name?: string;
+  readonly description?: string;
+  readonly family?: string;
+  readonly contextLength?: number;
+  readonly maxOutputTokens?: number;
+  readonly imageInput?: boolean;
+  readonly toolCalling?: boolean;
+  readonly reasoning?: boolean;
+  readonly reasoningOptions?: readonly string[];
+  readonly releaseDate?: string;
+  readonly lastUpdated?: string;
+}
+
+export interface ModelsDevSnapshot {
+  readonly fetchedAt: number;
+  readonly models: Readonly<Record<string, ModelsDevModelMetadata>>;
+}
+
+export interface MetadataCache {
+  get<T>(key: string): T | undefined;
+  update(key: string, value: unknown): PromiseLike<void>;
+}
+
+type Fetch = typeof fetch;
+
+export function normalizeModelsDevSnapshot(payload: unknown, fetchedAt: number): ModelsDevSnapshot {
+  const provider = asRecord(asRecord(payload)?.openai);
+  const rawModels = asRecord(provider?.models);
+  if (!rawModels) throw new Error("Models.dev returned no OpenAI model catalog");
+  const models = Object.fromEntries(Object.entries(rawModels).flatMap(([key, value]) => {
+    const model = normalizeModel(key, value);
+    return model ? [[model.id, model]] : [];
+  }));
+  if (!Object.keys(models).length) throw new Error("Models.dev returned no usable OpenAI models");
+  return { fetchedAt, models };
+}
+
+export function parseCachedModelsDevSnapshot(value: unknown): ModelsDevSnapshot | undefined {
+  const snapshot = asRecord(value);
+  const rawModels = asRecord(snapshot?.models);
+  if (!snapshot || !validTimestamp(snapshot.fetchedAt) || !rawModels) return undefined;
+  const models: Record<string, ModelsDevModelMetadata> = {};
+  for (const [key, raw] of Object.entries(rawModels)) {
+    const model = parseCachedModel(key, raw);
+    if (!model) return undefined;
+    models[model.id] = model;
+  }
+  return { fetchedAt: snapshot.fetchedAt, models };
+}
+
+export class ModelsDevMetadata {
+  private snapshot: ModelsDevSnapshot | undefined;
+  private refreshPromise: Promise<ModelsDevSnapshot> | undefined;
+  private loadedCache = false;
+
+  constructor(
+    private readonly cache: MetadataCache,
+    private readonly fetchImpl: Fetch = fetch,
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  async getOrRefresh(): Promise<ModelsDevSnapshot> {
+    this.loadCache();
+    if (!this.snapshot) return this.refresh();
+    if (this.now() - this.snapshot.fetchedAt >= MODELS_DEV_CACHE_TTL_MS) void this.refresh();
+    return this.snapshot;
+  }
+
+  async refresh(): Promise<ModelsDevSnapshot> {
+    this.loadCache();
+    if (this.refreshPromise) return this.refreshPromise;
+    this.refreshPromise = this.fetchAndCache().finally(() => { this.refreshPromise = undefined; });
+    return this.refreshPromise;
+  }
+
+  getModel(id: string): ModelsDevModelMetadata | undefined {
+    this.loadCache();
+    return this.snapshot?.models[id];
+  }
+
+  private async fetchAndCache(): Promise<ModelsDevSnapshot> {
+    try {
+      const response = await this.fetchImpl(MODELS_DEV_API_URL, { headers: { accept: "application/json" }, signal: timeoutSignal() });
+      if (!response.ok) throw new Error(`Models.dev metadata request failed: ${response.status}`);
+      const next = normalizeModelsDevSnapshot(await response.json(), this.now());
+      this.snapshot = next;
+      try { await this.cache.update(MODELS_DEV_CACHE_KEY, next); }
+      catch { /* A cache write must not hide a successful refresh. */ }
+      return next;
+    } catch {
+      return this.snapshot ?? { fetchedAt: 0, models: {} };
+    }
+  }
+
+  private loadCache(): void {
+    if (this.loadedCache) return;
+    this.loadedCache = true;
+    this.snapshot = parseCachedModelsDevSnapshot(this.cache.get<unknown>(MODELS_DEV_CACHE_KEY));
+  }
+}
+
+function normalizeModel(key: string, value: unknown): ModelsDevModelMetadata | undefined {
+  const raw = asRecord(value);
+  if (!raw) return undefined;
+  const id = stringValue(raw.id) ?? key.trim();
+  if (!id) return undefined;
+  const modalities = asRecord(raw.modalities);
+  const limit = asRecord(raw.limit);
+  return {
+    id,
+    name: optionalString(raw.name),
+    description: optionalString(raw.description),
+    family: optionalString(raw.family),
+    contextLength: optionalTokenCount(limit?.context),
+    maxOutputTokens: optionalTokenCount(limit?.output),
+    imageInput: stringArray(modalities?.input).includes("image"),
+    toolCalling: optionalBoolean(raw.tool_call),
+    reasoning: optionalBoolean(raw.reasoning),
+    reasoningOptions: normalizeReasoningOptions(raw.reasoning_options),
+    releaseDate: optionalString(raw.release_date),
+    lastUpdated: optionalString(raw.last_updated),
+  };
+}
+
+function parseCachedModel(key: string, value: unknown): ModelsDevModelMetadata | undefined {
+  const raw = asRecord(value);
+  if (!raw) return undefined;
+  const id = stringValue(raw.id) ?? key.trim();
+  if (!id || !validOptionalNumber(raw.contextLength) || !validOptionalNumber(raw.maxOutputTokens)) return undefined;
+  if (!validOptionalBoolean(raw.imageInput) || !validOptionalBoolean(raw.toolCalling) || !validOptionalBoolean(raw.reasoning)) return undefined;
+  if (raw.reasoningOptions !== undefined && !isStringArray(raw.reasoningOptions)) return undefined;
+  return {
+    id,
+    name: optionalString(raw.name),
+    description: optionalString(raw.description),
+    family: optionalString(raw.family),
+    contextLength: optionalTokenCount(raw.contextLength),
+    maxOutputTokens: optionalTokenCount(raw.maxOutputTokens),
+    imageInput: optionalBoolean(raw.imageInput),
+    toolCalling: optionalBoolean(raw.toolCalling),
+    reasoning: optionalBoolean(raw.reasoning),
+    reasoningOptions: raw.reasoningOptions === undefined ? undefined : stringArray(raw.reasoningOptions),
+    releaseDate: optionalString(raw.releaseDate),
+    lastUpdated: optionalString(raw.lastUpdated),
+  };
+}
+
+function normalizeReasoningOptions(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const options = [...new Set(value.flatMap((entry) => {
+    const option = asRecord(entry);
+    if (option?.type === "toggle") return ["toggle"];
+    return option?.type === "effort" ? stringArray(option.values) : [];
+  }))];
+  return options.length ? options : undefined;
+}
+
+function timeoutSignal(): AbortSignal | undefined {
+  return typeof AbortSignal.timeout === "function" ? AbortSignal.timeout(MODELS_DEV_TIMEOUT_MS) : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}
+
+function stringValue(value: unknown): string | undefined { return typeof value === "string" && value.trim() ? value.trim() : undefined; }
+function optionalString(value: unknown): string | undefined { return value === undefined ? undefined : stringValue(value); }
+function optionalBoolean(value: unknown): boolean | undefined { return typeof value === "boolean" ? value : undefined; }
+function optionalTokenCount(value: unknown): number | undefined { return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined; }
+function stringArray(value: unknown): string[] { return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []; }
+function isStringArray(value: unknown): value is string[] { return Array.isArray(value) && value.every((item) => typeof item === "string"); }
+function validTimestamp(value: unknown): value is number { return typeof value === "number" && Number.isFinite(value) && value >= 0; }
+function validOptionalNumber(value: unknown): boolean { return value === undefined || optionalTokenCount(value) !== undefined; }
+function validOptionalBoolean(value: unknown): boolean { return value === undefined || typeof value === "boolean"; }

--- a/src/models/options.test.ts
+++ b/src/models/options.test.ts
@@ -59,7 +59,7 @@ test("lets a normal model switch to Fast through its configuration", () => {
   });
 });
 
-test("falls back to live model defaults and reads legacy picker values", () => {
+test("falls back to the model option default and reads legacy picker values", () => {
   assert.deepEqual(
     resolveModelRequestOptions(
       spec,
@@ -161,6 +161,22 @@ test("carries the live Fast-tier description into the picker schema", () => {
     "Standard speed and usage",
     "Priority responses",
   ]);
+});
+
+test("defaults ordered reasoning controls to high when the model supports it", () => {
+  const optionSpec = modelOptionSpec({
+    reasoningLevels: [
+      { effort: "low", description: "Lighter reasoning" },
+      { effort: "high", description: "Deeper reasoning" },
+    ],
+    defaultReasoningEffort: "low",
+    supportsFast: false,
+    supportsReasoningSummaryParameter: false,
+    defaultReasoningSummary: "none",
+  });
+
+  assert.equal(optionSpec.defaultEffort, "high");
+  assert.equal(buildModelConfigurationSchema(optionSpec).properties.reasoningEffort.default, "high");
 });
 
 test("omits reasoning summaries when disabled or unsupported", () => {

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -48,10 +48,11 @@ export function modelOptionSpec(
     "reasoningLevels" | "defaultReasoningEffort" | "supportsFast" | "fastDescription" | "supportsReasoningSummaryParameter" | "defaultReasoningSummary"
   >,
 ): ModelOptionSpec {
+  const efforts = model.reasoningLevels.map((level) => level.effort);
   return {
-    efforts: model.reasoningLevels.map((level) => level.effort),
+    efforts,
     descriptions: Object.fromEntries(model.reasoningLevels.map((level) => [level.effort, level.description])),
-    defaultEffort: model.defaultReasoningEffort,
+    defaultEffort: efforts.includes("high") ? "high" : model.defaultReasoningEffort,
     supportsFast: model.supportsFast,
     fastDescription: model.fastDescription,
     supportsReasoningSummaryParameter: model.supportsReasoningSummaryParameter,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -13,6 +13,7 @@ import {
   type SpeedMode,
 } from "./models/options";
 import {
+  enrichCodexModel,
   expandCodexModelVariants,
   parseCodexModelsPayload,
   type CodexModelMetadata,
@@ -32,6 +33,7 @@ import {
 } from "./usage/domain";
 import { CodexTransport } from "./transport/client";
 import { CatalogCache } from "./models/catalog-cache";
+import { ModelsDevMetadata, type MetadataCache } from "./models/metadata";
 
 /** Live model information registered with VS Code Chat. */
 export interface CodexModel extends vscode.LanguageModelChatInformation {
@@ -63,12 +65,14 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
   private readonly modelCache = new CatalogCache<CodexModelMetadata[]>();
   private modelCacheAccount: string | undefined;
   private readonly transport: CodexTransport;
+  private readonly metadata: ModelsDevMetadata;
 
   constructor(
     private readonly oauth: OpenAIOAuth,
     private readonly output: vscode.OutputChannel,
     userAgent: string,
     initialUsage: CodexUsageSnapshot = {},
+    metadataCache: MetadataCache = memoryMetadataCache(),
     fetcher: typeof fetch = fetch,
   ) {
     this.usage = initialUsage;
@@ -78,6 +82,7 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
       () => configuration().get("requestTimeoutSeconds", 600),
       fetcher,
     );
+    this.metadata = new ModelsDevMetadata(metadataCache, fetcher);
   }
 
   fireDidChange(): void {
@@ -87,6 +92,18 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
   clearModelCache(): void {
     this.modelCache.clear();
     this.modelCacheAccount = undefined;
+  }
+
+  async refreshModels(): Promise<number> {
+    this.clearModelCache();
+    const cancellation = new vscode.CancellationTokenSource();
+    try {
+      const models = await this.fetchModels(cancellation.token);
+      this.fireDidChange();
+      return expandCodexModelVariants(models).length;
+    } finally {
+      cancellation.dispose();
+    }
   }
 
   getUsageSnapshot(): CodexUsageSnapshot {
@@ -253,7 +270,8 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
       if (!response.ok) throw await responseError("Unable to load OpenAI Codex models", response);
       const parsed = parseCodexModelsPayload(await response.json());
       if (!parsed.length) throw new Error("OpenAI Codex returned no usable models");
-      return parsed;
+      const metadata = await this.metadata.getOrRefresh();
+      return parsed.map((model) => enrichCodexModel(model, metadata.models[model.id]));
     }, () => cancellation.isCancellationRequested);
     this.modelCacheAccount = account;
     return models;
@@ -273,6 +291,14 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     this.usageEmitter.fire(usage);
   }
 
+}
+
+function memoryMetadataCache(): MetadataCache {
+  const values = new Map<string, unknown>();
+  return {
+    get<T>(key: string): T | undefined { return values.get(key) as T | undefined; },
+    async update(key: string, value: unknown): Promise<void> { values.set(key, value); },
+  };
 }
 
 function configuration(): vscode.WorkspaceConfiguration {

--- a/src/vscode/proposed-chat-provider.d.ts
+++ b/src/vscode/proposed-chat-provider.d.ts
@@ -9,6 +9,7 @@ declare module "vscode" {
     readonly pricing?: string;
     readonly isUserSelectable?: boolean;
     readonly configurationSchema?: LanguageModelConfigurationSchema;
+    readonly targetChatSessionType?: string;
   }
 
   export interface LanguageModelChatCapabilities {
@@ -16,15 +17,29 @@ declare module "vscode" {
     readonly toolCalling?: boolean | number;
   }
 
-  export type LanguageModelResponsePart2 = LanguageModelResponsePart | LanguageModelDataPart | LanguageModelThinkingPart;
+  export type LanguageModelResponsePart2 =
+    | LanguageModelResponsePart
+    | LanguageModelDataPart
+    | LanguageModelThinkingPart;
 
   export type LanguageModelConfigurationSchema = {
-    readonly type?: string;
-    readonly properties?: { readonly [key: string]: Record<string, unknown> };
+    readonly type?: "object";
+    readonly properties?: {
+      readonly [key: string]: Record<string, unknown> & {
+        readonly enumItemLabels?: string[];
+        readonly enumDescriptions?: string[];
+        readonly group?: string;
+      };
+    };
   };
 
-  export interface LanguageModelChatProvider<T extends LanguageModelChatInformation = LanguageModelChatInformation> {
-    provideLanguageModelChatInformation(options: PrepareLanguageModelChatModelOptions, token: CancellationToken): ProviderResult<T[]>;
+  export interface LanguageModelChatProvider<
+    T extends LanguageModelChatInformation = LanguageModelChatInformation,
+  > {
+    provideLanguageModelChatInformation(
+      options: PrepareLanguageModelChatModelOptions,
+      token: CancellationToken,
+    ): ProviderResult<T[]>;
     provideLanguageModelChatResponse(
       model: T,
       messages: readonly LanguageModelChatRequestMessage[],


### PR DESCRIPTION
## Summary\n\n- align the provider shell, model refresh, status, and diagnostics conventions\n- add persisted models.dev enrichment for live Codex discovery\n- synchronize model-picker reasoning defaults and concise documentation\n- mark the release as a minor bump to v0.9.0\n\n## Validation\n\n- npm run package\n- 63 tests passed