### PR TITLE
Add native multi-account Codex profiles

### DIFF
--- a/.changeset/native-multi-account-profiles.md
+++ b/.changeset/native-multi-account-profiles.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": minor
+---
+
+Add native named Codex Bridge provider entries with isolated ChatGPT OAuth profiles, model catalogs, refreshes, and usage state.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This native VS Code `LanguageModelChatProvider` handles OpenAI OAuth locally and
 ## Highlights
 
 - ChatGPT OAuth with PKCE, automatic refresh, and VS Code Secret Storage
+- Multiple named Codex Bridge entries for separate ChatGPT accounts
 - Live Codex model discovery with six-hour persisted models.dev enrichment
 - Streaming text, reasoning summaries, images, and agent-mode tool calls
 - Per-model reasoning effort, summary, Speed Mode, Web Search, and Image Generation controls
@@ -29,8 +30,9 @@ This native VS Code `LanguageModelChatProvider` handles OpenAI OAuth locally and
 ## Quick start
 
 1. Install [Codex Bridge for Copilot Chat](https://marketplace.visualstudio.com/items?itemName=grikomsn.openai-oauth-copilot-chat). You need VS Code 1.125 or newer, GitHub Copilot Chat, and a ChatGPT account with Codex access.
-2. Run **Codex Bridge: Manage Connection** and complete **Sign in with ChatGPT**. Use manual sign-in if local port `1455` is unavailable.
-3. Open Copilot Chat, select **Manage Models**, enable **Codex Bridge**, and choose a Codex model.
+2. Run **Codex Bridge: Add ChatGPT Account**, choose a short profile ID such as `personal`, and complete sign-in. Use manual sign-in if local port `1455` is unavailable.
+3. Open **Chat: Manage Language Models**, select **Add Models → Codex Bridge**, name the entry, and enter the same profile ID.
+4. Repeat those steps with another profile ID to keep work and personal ChatGPT accounts available side by side.
 
 The authenticated Codex catalog remains authoritative. Composer controls override workspace defaults; reasoning defaults to High when supported, while hosted Web Search and Image Generation remain off until enabled. Click the Codex status-bar item to inspect five-hour and weekly quota, reset timing, and tokens observed by this extension.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,7 +4,9 @@
 
 Run `code --install-extension openai-oauth-copilot-chat-0.1.0.vsix`, then reload VS Code.
 
-Use **Codex Bridge: Manage Connection** to authenticate. After sign-in, open Copilot Chat's model picker and enable a model under **Manage Models → Codex Bridge**.
+Use **Codex Bridge: Add ChatGPT Account** to authenticate and assign the account a profile ID. After sign-in, run **Chat: Manage Language Models**, choose **Add Models → Codex Bridge**, and enter the same profile ID. VS Code keeps each named entry separate, so multiple ChatGPT accounts can coexist in one window.
+
+The `default` profile preserves an existing single-account session, but after upgrading you must add a Codex Bridge entry in **Chat: Manage Language Models** and use `default` as its profile ID. **Codex Bridge: Select Active Profile** chooses which account the status bar and management commands display; model requests always use the account attached to the selected Language Models entry.
 
 Each model exposes the reasoning efforts advertised by the live Codex catalog. Ordered
 effort controls default to High when the model supports it; otherwise the catalog default
@@ -48,7 +50,7 @@ OpenAI's Codex OAuth client redirects to `http://localhost:1455/auth/callback`. 
 
 - Confirm VS Code is version 1.125 or newer.
 - Confirm GitHub Copilot Chat is installed and enabled.
-- Confirm Codex Bridge is signed in; model discovery uses the authenticated Codex catalog endpoint.
+- Confirm the profile ID in the Language Models entry matches a profile created by **Codex Bridge: Add ChatGPT Account**; model discovery uses that profile's authenticated Codex catalog endpoint.
 - Run **Codex Bridge: Show Diagnostics** and check that the provider reports registered models.
 - Open the model picker, choose **Manage Models**, and enable Codex Bridge models.
 - Your organization can disable bring-your-own-model providers through GitHub Copilot policy.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,14 @@
         "title": "Codex Bridge: Manage Connection"
       },
       {
+        "command": "openaiCodex.addAccount",
+        "title": "Codex Bridge: Add ChatGPT Account"
+      },
+      {
+        "command": "openaiCodex.selectProfile",
+        "title": "Codex Bridge: Select Active Profile"
+      },
+      {
         "command": "openaiCodex.signIn",
         "title": "Codex Bridge: Sign In with ChatGPT"
       },
@@ -148,7 +156,21 @@
       {
         "vendor": "openai-codex",
         "displayName": "Codex Bridge",
-        "managementCommand": "openaiCodex.manage"
+        "configuration": {
+          "type": "object",
+          "required": [
+            "profile"
+          ],
+          "properties": {
+            "profile": {
+              "type": "string",
+              "title": "Codex Bridge Profile",
+              "description": "Profile ID created with Codex Bridge: Add ChatGPT Account (for example, personal or work).",
+              "default": "default",
+              "pattern": "^[a-z0-9][a-z0-9._-]{0,63}$"
+            }
+          }
+        }
       }
     ]
   },

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type * as vscode from "vscode";
-import { decodeJwt, OpenAIOAuth, parseCallback } from "./auth";
+import { decodeJwt, normalizeProfileId, OpenAIOAuth, parseCallback } from "./auth";
 import { OAUTH_ORIGINATOR } from "../transport/protocol";
 
 test("parses OAuth callback URLs", () => {
@@ -40,4 +40,37 @@ test("rejects OAuth callbacks with missing or mismatched state before token exch
     /Invalid OpenAI OAuth callback state/,
   );
   assert.equal(fetchCalls, 0);
+});
+
+test("stores and resolves OAuth sessions independently by profile", async () => {
+  const values = new Map<string, string>();
+  const secrets = {
+    get: async (key: string) => values.get(key),
+    store: async (key: string, value: string) => { values.set(key, value); },
+    delete: async (key: string) => { values.delete(key); },
+  } as unknown as vscode.SecretStorage;
+  let token = "personal-token";
+  const fetcher = (async () => new Response(JSON.stringify({
+    access_token: token,
+    refresh_token: `${token}-refresh`,
+    expires_in: 3600,
+  }), { status: 200, headers: { "Content-Type": "application/json" } })) as typeof fetch;
+  const oauth = new OpenAIOAuth(secrets, fetcher, () => 1_000);
+  const flow = { url: "https://auth.openai.com", state: "state", verifier: "verifier" };
+
+  await oauth.completeAuthorization("?code=one&state=state", flow, "personal");
+  token = "work-token";
+  await oauth.completeAuthorization("?code=two&state=state", flow, "work");
+
+  assert.deepEqual(await oauth.listProfiles(), ["personal", "work"]);
+  assert.equal((await oauth.getAccessToken(false, "personal")).token, "personal-token");
+  assert.equal((await oauth.getAccessToken(false, "work")).token, "work-token");
+  await oauth.signOut("personal");
+  assert.equal(await oauth.hasSession("personal"), false);
+  assert.equal(await oauth.hasSession("work"), true);
+});
+
+test("normalizes safe profile IDs and rejects ambiguous values", () => {
+  assert.equal(normalizeProfileId(" Work.Profile "), "work.profile");
+  assert.throws(() => normalizeProfileId("work profile"), /Profile IDs/);
 });

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -141,3 +141,26 @@ test("does not persist an authorization exchange that finishes after sign-out", 
   await assert.rejects(signingIn, /was superseded/);
   assert.equal(await oauth.hasSession("work"), false);
 });
+
+test("does not start a late manual callback after sign-out", async () => {
+  const values = new Map<string, string>();
+  const secrets = {
+    get: async (key: string) => values.get(key),
+    store: async (key: string, value: string) => { values.set(key, value); },
+    delete: async (key: string) => { values.delete(key); },
+  } as unknown as vscode.SecretStorage;
+  let fetchCalls = 0;
+  const oauth = new OpenAIOAuth(secrets, (async () => {
+    fetchCalls += 1;
+    return Response.json({ access_token: "access", refresh_token: "refresh", expires_in: 3600 });
+  }) as typeof fetch, () => 1_000);
+  const attempt = oauth.startManualSignIn("work");
+  await oauth.signOut("work");
+
+  await assert.rejects(
+    attempt.complete(`?code=one&state=${attempt.flow.state}`),
+    /was superseded/,
+  );
+  assert.equal(fetchCalls, 0);
+  assert.equal(await oauth.hasSession("work"), false);
+});

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -117,6 +117,27 @@ test("does not persist a refresh that finishes after sign-out", async () => {
   const refreshing = oauth.getAccessToken(false, "work");
   await oauth.signOut("work");
   release();
-  await refreshing;
+  await assert.rejects(refreshing, /changed while its session was refreshing/);
+  assert.equal(await oauth.hasSession("work"), false);
+});
+
+test("does not persist an authorization exchange that finishes after sign-out", async () => {
+  const values = new Map<string, string>();
+  const secrets = {
+    get: async (key: string) => values.get(key),
+    store: async (key: string, value: string) => { values.set(key, value); },
+    delete: async (key: string) => { values.delete(key); },
+  } as unknown as vscode.SecretStorage;
+  let release!: () => void;
+  const wait = new Promise<void>((resolve) => { release = resolve; });
+  const oauth = new OpenAIOAuth(secrets, (async () => {
+    await wait;
+    return Response.json({ access_token: "access", refresh_token: "refresh", expires_in: 3600 });
+  }) as typeof fetch, () => 1_000);
+  const flow = { url: "https://auth.openai.com", state: "state", verifier: "verifier" };
+  const signingIn = oauth.completeAuthorization("?code=one&state=state", flow, "work");
+  await oauth.signOut("work");
+  release();
+  await assert.rejects(signingIn, /was superseded/);
   assert.equal(await oauth.hasSession("work"), false);
 });

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -164,3 +164,34 @@ test("does not start a late manual callback after sign-out", async () => {
   assert.equal(fetchCalls, 0);
   assert.equal(await oauth.hasSession("work"), false);
 });
+
+test("removes an authorization write superseded during SecretStorage persistence", async () => {
+  const values = new Map<string, string>();
+  let persistenceStarted!: () => void;
+  let releasePersistence!: () => void;
+  const started = new Promise<void>((resolve) => { persistenceStarted = resolve; });
+  const wait = new Promise<void>((resolve) => { releasePersistence = resolve; });
+  const secrets = {
+    get: async (key: string) => values.get(key),
+    store: async (key: string, value: string) => {
+      values.set(key, value);
+      if (key === "openaiCodex.oauthSession.v2.work") {
+        persistenceStarted();
+        await wait;
+      }
+    },
+    delete: async (key: string) => { values.delete(key); },
+  } as unknown as vscode.SecretStorage;
+  const oauth = new OpenAIOAuth(secrets, (async () => Response.json({
+    access_token: "access", refresh_token: "refresh", expires_in: 3600,
+  })) as typeof fetch, () => 1_000);
+  const first = oauth.startManualSignIn("work");
+  const completing = first.complete(`?code=one&state=${first.flow.state}`);
+  await started;
+  oauth.startManualSignIn("work");
+  releasePersistence();
+
+  await assert.rejects(completing, /was superseded/);
+  assert.equal(await oauth.hasSession("work"), false);
+  assert.deepEqual(await oauth.listProfiles(), []);
+});

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -74,3 +74,49 @@ test("normalizes safe profile IDs and rejects ambiguous values", () => {
   assert.equal(normalizeProfileId(" Work.Profile "), "work.profile");
   assert.throws(() => normalizeProfileId("work profile"), /Profile IDs/);
 });
+
+test("serializes concurrent profile-index updates", async () => {
+  const values = new Map<string, string>();
+  const secrets = {
+    get: async (key: string) => values.get(key),
+    store: async (key: string, value: string) => {
+      if (key.includes("oauthProfiles")) await new Promise((resolve) => setTimeout(resolve, 5));
+      values.set(key, value);
+    },
+    delete: async (key: string) => { values.delete(key); },
+  } as unknown as vscode.SecretStorage;
+  const oauth = new OpenAIOAuth(secrets, (async (_input, init) => {
+    const code = new URLSearchParams(String(init?.body)).get("code");
+    return Response.json({ access_token: `${code}-access`, refresh_token: `${code}-refresh`, expires_in: 3600 });
+  }) as typeof fetch, () => 1_000);
+  const flow = { url: "https://auth.openai.com", state: "state", verifier: "verifier" };
+
+  await Promise.all([
+    oauth.completeAuthorization("?code=personal&state=state", flow, "personal"),
+    oauth.completeAuthorization("?code=work&state=state", flow, "work"),
+  ]);
+  assert.deepEqual(await oauth.listProfiles(), ["personal", "work"]);
+});
+
+test("does not persist a refresh that finishes after sign-out", async () => {
+  const values = new Map<string, string>([["openaiCodex.oauthSession.v2.work", JSON.stringify({
+    accessToken: "old-access", refreshToken: "old-refresh", expiresAt: 0,
+  })]]);
+  const secrets = {
+    get: async (key: string) => values.get(key),
+    store: async (key: string, value: string) => { values.set(key, value); },
+    delete: async (key: string) => { values.delete(key); },
+  } as unknown as vscode.SecretStorage;
+  let release!: () => void;
+  const wait = new Promise<void>((resolve) => { release = resolve; });
+  const oauth = new OpenAIOAuth(secrets, (async () => {
+    await wait;
+    return Response.json({ access_token: "refreshed", refresh_token: "rotated", expires_in: 3600 });
+  }) as typeof fetch, () => 1_000);
+
+  const refreshing = oauth.getAccessToken(false, "work");
+  await oauth.signOut("work");
+  release();
+  await refreshing;
+  assert.equal(await oauth.hasSession("work"), false);
+});

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -299,6 +299,11 @@ export class OpenAIOAuth {
       }
       await this.storeSession(normalized, session);
       if (this.profileGeneration(normalized) !== expectedGeneration) {
+        const current = await this.loadSession(normalized);
+        if (current && sessionIdentity(current) === sessionIdentity(session)) {
+          await this.secrets.delete(profileSecretKey(normalized));
+          await this.mutateProfileIndex((profiles) => profiles.delete(normalized));
+        }
         throw new Error(`OpenAI Codex sign-in for profile “${normalized}” was superseded`);
       }
     });

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -47,6 +47,12 @@ export interface BrowserSignIn {
   cancel(): void;
 }
 
+/** Manual authorization attempt bound to the profile generation at launch. */
+export interface ManualSignIn {
+  flow: AuthorizationFlow;
+  complete(callbackInput: string): Promise<OAuthSession>;
+}
+
 type Fetcher = typeof fetch;
 
 /**
@@ -109,6 +115,16 @@ export class OpenAIOAuth {
     url.searchParams.set("codex_cli_simplified_flow", "true");
     url.searchParams.set("originator", OAUTH_ORIGINATOR);
     return { url: url.toString(), state, verifier };
+  }
+
+  startManualSignIn(profile = DEFAULT_OAUTH_PROFILE): ManualSignIn {
+    const normalized = normalizeProfileId(profile);
+    const generation = this.beginSessionReplacement(normalized);
+    const flow = this.createAuthorizationFlow();
+    return {
+      flow,
+      complete: (callbackInput) => this.completeAuthorization(callbackInput, flow, normalized, generation),
+    };
   }
 
   async startBrowserSignIn(profile = DEFAULT_OAUTH_PROFILE): Promise<BrowserSignIn> {
@@ -190,6 +206,9 @@ export class OpenAIOAuth {
     if (callback.error) throw new Error(callback.errorDescription ?? callback.error);
     if (!callback.code) throw new Error("The callback does not contain an authorization code");
     if (callback.state !== flow.state) throw new Error("Invalid OpenAI OAuth callback state");
+    if (this.profileGeneration(normalized) !== generation) {
+      throw new Error(`OpenAI Codex sign-in for profile “${normalized}” was superseded`);
+    }
     const response = await this.fetcher(OPENAI_TOKEN_URL, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
@@ -239,6 +258,7 @@ export class OpenAIOAuth {
 
   private async refresh(profile: string, session: OAuthSession): Promise<OAuthSession> {
     const identity = sessionIdentity(session);
+    const generation = this.profileGeneration(profile);
     const existing = this.refreshPromises.get(profile);
     if (existing?.identity === identity) return existing.promise;
     let refreshPromise: Promise<OAuthSession>;
@@ -257,9 +277,9 @@ export class OpenAIOAuth {
         let persisted = false;
         await this.mutateSession(profile, async () => {
           const current = await this.loadSession(profile);
-          if (current && sessionIdentity(current) === identity) {
+          if (this.profileGeneration(profile) === generation && current && sessionIdentity(current) === identity) {
             await this.storeSession(profile, refreshed);
-            persisted = true;
+            persisted = this.profileGeneration(profile) === generation;
           }
         });
         if (!persisted) throw new Error(`OpenAI Codex profile “${profile}” changed while its session was refreshing`);
@@ -278,6 +298,9 @@ export class OpenAIOAuth {
         throw new Error(`OpenAI Codex sign-in for profile “${normalized}” was superseded`);
       }
       await this.storeSession(normalized, session);
+      if (this.profileGeneration(normalized) !== expectedGeneration) {
+        throw new Error(`OpenAI Codex sign-in for profile “${normalized}” was superseded`);
+      }
     });
   }
 

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -59,6 +59,7 @@ export class OpenAIOAuth {
   private readonly refreshPromises = new Map<string, { identity: string; promise: Promise<OAuthSession> }>();
   private readonly sessionMutations = new Map<string, Promise<void>>();
   private profileIndexMutation: Promise<void> = Promise.resolve();
+  private readonly profileGenerations = new Map<string, number>();
 
   constructor(
     private readonly secrets: vscode.SecretStorage,
@@ -83,6 +84,7 @@ export class OpenAIOAuth {
 
   async signOut(profile = DEFAULT_OAUTH_PROFILE): Promise<void> {
     const normalized = normalizeProfileId(profile);
+    this.invalidateProfile(normalized);
     await this.mutateSession(normalized, async () => {
       await this.secrets.delete(profileSecretKey(normalized));
       if (normalized === DEFAULT_OAUTH_PROFILE) await this.secrets.delete(LEGACY_SECRET_KEY);
@@ -111,6 +113,7 @@ export class OpenAIOAuth {
 
   async startBrowserSignIn(profile = DEFAULT_OAUTH_PROFILE): Promise<BrowserSignIn> {
     const normalizedProfile = normalizeProfileId(profile);
+    const generation = this.beginSessionReplacement(normalizedProfile);
     const flow = this.createAuthorizationFlow();
     let server: Server | undefined;
     let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -135,7 +138,7 @@ export class OpenAIOAuth {
           return;
         }
         try {
-          const session = await this.completeAuthorization(callback.toString(), flow, normalizedProfile);
+          const session = await this.completeAuthorization(callback.toString(), flow, normalizedProfile, generation);
           settled = true;
           response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
           response.end(callbackPage(`Signed in to ${EXTENSION_DISPLAY_NAME}`, "You can close this tab and return to Visual Studio Code."));
@@ -179,7 +182,10 @@ export class OpenAIOAuth {
     callbackInput: string,
     flow: AuthorizationFlow,
     profile = DEFAULT_OAUTH_PROFILE,
+    expectedGeneration?: number,
   ): Promise<OAuthSession> {
+    const normalized = normalizeProfileId(profile);
+    const generation = expectedGeneration ?? this.beginSessionReplacement(normalized);
     const callback = parseCallback(callbackInput);
     if (callback.error) throw new Error(callback.errorDescription ?? callback.error);
     if (!callback.code) throw new Error("The callback does not contain an authorization code");
@@ -197,7 +203,7 @@ export class OpenAIOAuth {
     });
     if (!response.ok) throw await responseError("OpenAI token exchange failed", response);
     const session = tokenResponseToSession(await response.json(), undefined, this.now());
-    await this.saveSession(profile, session);
+    await this.saveSession(normalized, session, generation);
     return session;
   }
 
@@ -211,6 +217,8 @@ export class OpenAIOAuth {
   }
 
   async importCodexCliSession(profile = DEFAULT_OAUTH_PROFILE): Promise<OAuthSession> {
+    const normalized = normalizeProfileId(profile);
+    const generation = this.beginSessionReplacement(normalized);
     const authPath = join(homedir(), ".codex", "auth.json");
     const parsed = JSON.parse(await readFile(authPath, "utf8")) as Record<string, unknown>;
     const tokens = recordField(parsed, "tokens") ?? parsed;
@@ -225,7 +233,7 @@ export class OpenAIOAuth {
       accountId: extractAccountId(claims),
       email: typeof claims?.email === "string" ? claims.email : undefined,
     };
-    await this.saveSession(profile, session);
+    await this.saveSession(normalized, session, generation);
     return session;
   }
 
@@ -246,12 +254,15 @@ export class OpenAIOAuth {
         });
         if (!response.ok) throw await responseError("OpenAI token refresh failed", response);
         const refreshed = tokenResponseToSession(await response.json(), session.refreshToken, this.now());
+        let persisted = false;
         await this.mutateSession(profile, async () => {
           const current = await this.loadSession(profile);
           if (current && sessionIdentity(current) === identity) {
             await this.storeSession(profile, refreshed);
+            persisted = true;
           }
         });
+        if (!persisted) throw new Error(`OpenAI Codex profile “${profile}” changed while its session was refreshing`);
         return refreshed;
       })().finally(() => {
         if (this.refreshPromises.get(profile)?.promise === refreshPromise) this.refreshPromises.delete(profile);
@@ -260,9 +271,14 @@ export class OpenAIOAuth {
     return refreshPromise;
   }
 
-  private async saveSession(profile: string, session: OAuthSession): Promise<void> {
+  private async saveSession(profile: string, session: OAuthSession, expectedGeneration: number): Promise<void> {
     const normalized = normalizeProfileId(profile);
-    await this.mutateSession(normalized, () => this.storeSession(normalized, session));
+    await this.mutateSession(normalized, async () => {
+      if (this.profileGeneration(normalized) !== expectedGeneration) {
+        throw new Error(`OpenAI Codex sign-in for profile “${normalized}” was superseded`);
+      }
+      await this.storeSession(normalized, session);
+    });
   }
 
   private async storeSession(profile: string, session: OAuthSession): Promise<void> {
@@ -319,6 +335,20 @@ export class OpenAIOAuth {
     });
     this.profileIndexMutation = current;
     await current;
+  }
+
+  private profileGeneration(profile: string): number {
+    return this.profileGenerations.get(profile) ?? 0;
+  }
+
+  private beginSessionReplacement(profile: string): number {
+    const generation = this.profileGeneration(profile) + 1;
+    this.profileGenerations.set(profile, generation);
+    return generation;
+  }
+
+  private invalidateProfile(profile: string): void {
+    this.profileGenerations.set(profile, this.profileGeneration(profile) + 1);
   }
 }
 

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -56,7 +56,9 @@ type Fetcher = typeof fetch;
  * access token and optional ChatGPT account identifier needed for a request.
  */
 export class OpenAIOAuth {
-  private readonly refreshPromises = new Map<string, Promise<OAuthSession>>();
+  private readonly refreshPromises = new Map<string, { identity: string; promise: Promise<OAuthSession> }>();
+  private readonly sessionMutations = new Map<string, Promise<void>>();
+  private profileIndexMutation: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly secrets: vscode.SecretStorage,
@@ -81,11 +83,11 @@ export class OpenAIOAuth {
 
   async signOut(profile = DEFAULT_OAUTH_PROFILE): Promise<void> {
     const normalized = normalizeProfileId(profile);
-    await this.secrets.delete(profileSecretKey(normalized));
-    if (normalized === DEFAULT_OAUTH_PROFILE) await this.secrets.delete(LEGACY_SECRET_KEY);
-    const profiles = await this.readProfileIndex();
-    profiles.delete(normalized);
-    await this.writeProfileIndex(profiles);
+    await this.mutateSession(normalized, async () => {
+      await this.secrets.delete(profileSecretKey(normalized));
+      if (normalized === DEFAULT_OAUTH_PROFILE) await this.secrets.delete(LEGACY_SECRET_KEY);
+      await this.mutateProfileIndex((profiles) => profiles.delete(normalized));
+    });
   }
 
   createAuthorizationFlow(): AuthorizationFlow {
@@ -228,9 +230,11 @@ export class OpenAIOAuth {
   }
 
   private async refresh(profile: string, session: OAuthSession): Promise<OAuthSession> {
-    let refreshPromise = this.refreshPromises.get(profile);
-    if (!refreshPromise) {
-      refreshPromise = (async () => {
+    const identity = sessionIdentity(session);
+    const existing = this.refreshPromises.get(profile);
+    if (existing?.identity === identity) return existing.promise;
+    let refreshPromise: Promise<OAuthSession>;
+    refreshPromise = (async () => {
         const response = await this.fetcher(OPENAI_TOKEN_URL, {
           method: "POST",
           headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
@@ -242,20 +246,29 @@ export class OpenAIOAuth {
         });
         if (!response.ok) throw await responseError("OpenAI token refresh failed", response);
         const refreshed = tokenResponseToSession(await response.json(), session.refreshToken, this.now());
-        await this.saveSession(profile, refreshed);
+        await this.mutateSession(profile, async () => {
+          const current = await this.loadSession(profile);
+          if (current && sessionIdentity(current) === identity) {
+            await this.storeSession(profile, refreshed);
+          }
+        });
         return refreshed;
-      })().finally(() => { this.refreshPromises.delete(profile); });
-      this.refreshPromises.set(profile, refreshPromise);
-    }
+      })().finally(() => {
+        if (this.refreshPromises.get(profile)?.promise === refreshPromise) this.refreshPromises.delete(profile);
+      });
+    this.refreshPromises.set(profile, { identity, promise: refreshPromise });
     return refreshPromise;
   }
 
   private async saveSession(profile: string, session: OAuthSession): Promise<void> {
     const normalized = normalizeProfileId(profile);
+    await this.mutateSession(normalized, () => this.storeSession(normalized, session));
+  }
+
+  private async storeSession(profile: string, session: OAuthSession): Promise<void> {
+    const normalized = normalizeProfileId(profile);
     await this.secrets.store(profileSecretKey(normalized), JSON.stringify(session));
-    const profiles = await this.readProfileIndex();
-    profiles.add(normalized);
-    await this.writeProfileIndex(profiles);
+    await this.mutateProfileIndex((profiles) => { profiles.add(normalized); });
   }
 
   private async loadSession(profile: string): Promise<OAuthSession | undefined> {
@@ -286,6 +299,27 @@ export class OpenAIOAuth {
   private async writeProfileIndex(profiles: ReadonlySet<string>): Promise<void> {
     await this.secrets.store(PROFILE_INDEX_KEY, JSON.stringify([...profiles].sort()));
   }
+
+  private async mutateSession(profile: string, operation: () => Promise<void>): Promise<void> {
+    const previous = this.sessionMutations.get(profile) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(operation);
+    this.sessionMutations.set(profile, current);
+    try {
+      await current;
+    } finally {
+      if (this.sessionMutations.get(profile) === current) this.sessionMutations.delete(profile);
+    }
+  }
+
+  private async mutateProfileIndex(operation: (profiles: Set<string>) => void): Promise<void> {
+    const current = this.profileIndexMutation.catch(() => undefined).then(async () => {
+      const profiles = await this.readProfileIndex();
+      operation(profiles);
+      await this.writeProfileIndex(profiles);
+    });
+    this.profileIndexMutation = current;
+    await current;
+  }
 }
 
 export function normalizeProfileId(value: string): string {
@@ -299,6 +333,10 @@ export function normalizeProfileId(value: string): string {
 
 function profileSecretKey(profile: string): string {
   return `${PROFILE_SECRET_PREFIX}${profile}`;
+}
+
+function sessionIdentity(session: OAuthSession): string {
+  return `${session.accessToken}\u0000${session.refreshToken}\u0000${session.expiresAt}`;
 }
 
 export function parseCallback(input: string): { code?: string; state?: string; error?: string; errorDescription?: string } {

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -19,7 +19,10 @@ import {
 const CALLBACK_PORT = 1455;
 const CALLBACK_PATH = "/auth/callback";
 const SCOPE = "openid email profile offline_access";
-const SECRET_KEY = "openaiCodex.oauthSession.v1";
+const LEGACY_SECRET_KEY = "openaiCodex.oauthSession.v1";
+const PROFILE_INDEX_KEY = "openaiCodex.oauthProfiles.v2";
+const PROFILE_SECRET_PREFIX = "openaiCodex.oauthSession.v2.";
+export const DEFAULT_OAUTH_PROFILE = "default";
 
 /** Persisted OAuth credentials used for ChatGPT Codex requests. */
 export interface OAuthSession {
@@ -53,7 +56,7 @@ type Fetcher = typeof fetch;
  * access token and optional ChatGPT account identifier needed for a request.
  */
 export class OpenAIOAuth {
-  private refreshPromise: Promise<OAuthSession> | undefined;
+  private readonly refreshPromises = new Map<string, Promise<OAuthSession>>();
 
   constructor(
     private readonly secrets: vscode.SecretStorage,
@@ -61,17 +64,28 @@ export class OpenAIOAuth {
     private readonly now: () => number = Date.now,
   ) {}
 
-  async hasSession(): Promise<boolean> {
-    return Boolean(await this.loadSession());
+  async hasSession(profile = DEFAULT_OAUTH_PROFILE): Promise<boolean> {
+    return Boolean(await this.loadSession(profile));
   }
 
-  async sessionInfo(): Promise<Pick<OAuthSession, "email" | "accountId" | "expiresAt"> | undefined> {
-    const session = await this.loadSession();
+  async sessionInfo(profile = DEFAULT_OAUTH_PROFILE): Promise<Pick<OAuthSession, "email" | "accountId" | "expiresAt"> | undefined> {
+    const session = await this.loadSession(profile);
     return session ? { email: session.email, accountId: session.accountId, expiresAt: session.expiresAt } : undefined;
   }
 
-  async signOut(): Promise<void> {
-    await this.secrets.delete(SECRET_KEY);
+  async listProfiles(): Promise<readonly string[]> {
+    const profiles = await this.readProfileIndex();
+    if (await this.secrets.get(LEGACY_SECRET_KEY)) profiles.add(DEFAULT_OAUTH_PROFILE);
+    return [...profiles].sort();
+  }
+
+  async signOut(profile = DEFAULT_OAUTH_PROFILE): Promise<void> {
+    const normalized = normalizeProfileId(profile);
+    await this.secrets.delete(profileSecretKey(normalized));
+    if (normalized === DEFAULT_OAUTH_PROFILE) await this.secrets.delete(LEGACY_SECRET_KEY);
+    const profiles = await this.readProfileIndex();
+    profiles.delete(normalized);
+    await this.writeProfileIndex(profiles);
   }
 
   createAuthorizationFlow(): AuthorizationFlow {
@@ -93,7 +107,8 @@ export class OpenAIOAuth {
     return { url: url.toString(), state, verifier };
   }
 
-  async startBrowserSignIn(): Promise<BrowserSignIn> {
+  async startBrowserSignIn(profile = DEFAULT_OAUTH_PROFILE): Promise<BrowserSignIn> {
+    const normalizedProfile = normalizeProfileId(profile);
     const flow = this.createAuthorizationFlow();
     let server: Server | undefined;
     let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -118,7 +133,7 @@ export class OpenAIOAuth {
           return;
         }
         try {
-          const session = await this.completeAuthorization(callback.toString(), flow);
+          const session = await this.completeAuthorization(callback.toString(), flow, normalizedProfile);
           settled = true;
           response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
           response.end(callbackPage(`Signed in to ${EXTENSION_DISPLAY_NAME}`, "You can close this tab and return to Visual Studio Code."));
@@ -158,7 +173,11 @@ export class OpenAIOAuth {
     };
   }
 
-  async completeAuthorization(callbackInput: string, flow: AuthorizationFlow): Promise<OAuthSession> {
+  async completeAuthorization(
+    callbackInput: string,
+    flow: AuthorizationFlow,
+    profile = DEFAULT_OAUTH_PROFILE,
+  ): Promise<OAuthSession> {
     const callback = parseCallback(callbackInput);
     if (callback.error) throw new Error(callback.errorDescription ?? callback.error);
     if (!callback.code) throw new Error("The callback does not contain an authorization code");
@@ -176,19 +195,20 @@ export class OpenAIOAuth {
     });
     if (!response.ok) throw await responseError("OpenAI token exchange failed", response);
     const session = tokenResponseToSession(await response.json(), undefined, this.now());
-    await this.saveSession(session);
+    await this.saveSession(profile, session);
     return session;
   }
 
-  async getAccessToken(forceRefresh = false): Promise<{ token: string; accountId?: string }> {
-    const session = await this.loadSession();
-    if (!session) throw new Error("Sign in to OpenAI Codex first");
+  async getAccessToken(forceRefresh = false, profile = DEFAULT_OAUTH_PROFILE): Promise<{ token: string; accountId?: string }> {
+    const normalizedProfile = normalizeProfileId(profile);
+    const session = await this.loadSession(normalizedProfile);
+    if (!session) throw new Error(`Sign in to OpenAI Codex profile “${normalizedProfile}” first`);
     const valid = !forceRefresh && session.expiresAt > this.now() + 60_000;
-    const current = valid ? session : await this.refresh(session);
+    const current = valid ? session : await this.refresh(normalizedProfile, session);
     return { token: current.accessToken, accountId: current.accountId };
   }
 
-  async importCodexCliSession(): Promise<OAuthSession> {
+  async importCodexCliSession(profile = DEFAULT_OAUTH_PROFILE): Promise<OAuthSession> {
     const authPath = join(homedir(), ".codex", "auth.json");
     const parsed = JSON.parse(await readFile(authPath, "utf8")) as Record<string, unknown>;
     const tokens = recordField(parsed, "tokens") ?? parsed;
@@ -203,13 +223,14 @@ export class OpenAIOAuth {
       accountId: extractAccountId(claims),
       email: typeof claims?.email === "string" ? claims.email : undefined,
     };
-    await this.saveSession(session);
+    await this.saveSession(profile, session);
     return session;
   }
 
-  private async refresh(session: OAuthSession): Promise<OAuthSession> {
-    if (!this.refreshPromise) {
-      this.refreshPromise = (async () => {
+  private async refresh(profile: string, session: OAuthSession): Promise<OAuthSession> {
+    let refreshPromise = this.refreshPromises.get(profile);
+    if (!refreshPromise) {
+      refreshPromise = (async () => {
         const response = await this.fetcher(OPENAI_TOKEN_URL, {
           method: "POST",
           headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
@@ -221,19 +242,26 @@ export class OpenAIOAuth {
         });
         if (!response.ok) throw await responseError("OpenAI token refresh failed", response);
         const refreshed = tokenResponseToSession(await response.json(), session.refreshToken, this.now());
-        await this.saveSession(refreshed);
+        await this.saveSession(profile, refreshed);
         return refreshed;
-      })().finally(() => { this.refreshPromise = undefined; });
+      })().finally(() => { this.refreshPromises.delete(profile); });
+      this.refreshPromises.set(profile, refreshPromise);
     }
-    return this.refreshPromise;
+    return refreshPromise;
   }
 
-  private async saveSession(session: OAuthSession): Promise<void> {
-    await this.secrets.store(SECRET_KEY, JSON.stringify(session));
+  private async saveSession(profile: string, session: OAuthSession): Promise<void> {
+    const normalized = normalizeProfileId(profile);
+    await this.secrets.store(profileSecretKey(normalized), JSON.stringify(session));
+    const profiles = await this.readProfileIndex();
+    profiles.add(normalized);
+    await this.writeProfileIndex(profiles);
   }
 
-  private async loadSession(): Promise<OAuthSession | undefined> {
-    const raw = await this.secrets.get(SECRET_KEY);
+  private async loadSession(profile: string): Promise<OAuthSession | undefined> {
+    const normalized = normalizeProfileId(profile);
+    const raw = await this.secrets.get(profileSecretKey(normalized))
+      ?? (normalized === DEFAULT_OAUTH_PROFILE ? await this.secrets.get(LEGACY_SECRET_KEY) : undefined);
     if (!raw) return undefined;
     try {
       const value = JSON.parse(raw) as OAuthSession;
@@ -243,6 +271,34 @@ export class OpenAIOAuth {
       return undefined;
     }
   }
+
+  private async readProfileIndex(): Promise<Set<string>> {
+    const raw = await this.secrets.get(PROFILE_INDEX_KEY);
+    if (!raw) return new Set<string>();
+    try {
+      const value = JSON.parse(raw) as unknown;
+      return new Set(Array.isArray(value) ? value.flatMap((item) => typeof item === "string" ? [normalizeProfileId(item)] : []) : []);
+    } catch {
+      return new Set<string>();
+    }
+  }
+
+  private async writeProfileIndex(profiles: ReadonlySet<string>): Promise<void> {
+    await this.secrets.store(PROFILE_INDEX_KEY, JSON.stringify([...profiles].sort()));
+  }
+}
+
+export function normalizeProfileId(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return DEFAULT_OAUTH_PROFILE;
+  if (!/^[a-z0-9][a-z0-9._-]{0,63}$/.test(normalized)) {
+    throw new Error("Profile IDs must use 1-64 lowercase letters, numbers, dots, underscores, or hyphens");
+  }
+  return normalized;
+}
+
+function profileSecretKey(profile: string): string {
+  return `${PROFILE_SECRET_PREFIX}${profile}`;
 }
 
 export function parseCallback(input: string): { code?: string; state?: string; error?: string; errorDescription?: string } {

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -105,7 +105,8 @@ async function manualSignIn(
   output: vscode.OutputChannel,
   profile = DEFAULT_OAUTH_PROFILE,
 ): Promise<void> {
-  const flow: AuthorizationFlow = oauth.createAuthorizationFlow();
+  const attempt = oauth.startManualSignIn(profile);
+  const flow: AuthorizationFlow = attempt.flow;
   try {
     await vscode.env.clipboard.writeText(flow.url);
     await vscode.env.openExternal(vscode.Uri.parse(flow.url));
@@ -115,7 +116,7 @@ async function manualSignIn(
       ignoreFocusOut: true,
     });
     if (!callback) return;
-    await oauth.completeAuthorization(callback, flow, profile);
+    await attempt.complete(callback);
     provider.setActiveProfile(profile);
     provider.clearModelCache(profile);
     provider.fireDidChange();

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -223,13 +223,16 @@ async function refreshModels(provider: OpenAICodexProvider, output: vscode.Outpu
   }
 }
 
-async function showUsage(provider: OpenAICodexProvider, output: vscode.OutputChannel): Promise<void> {
-  const profile = provider.getActiveProfile();
-  let snapshot = provider.getUsageSnapshot();
+async function showUsage(
+  provider: OpenAICodexProvider,
+  output: vscode.OutputChannel,
+  profile = provider.getActiveProfile(),
+): Promise<void> {
+  let snapshot = provider.getUsageSnapshot(profile);
   try {
     snapshot = await vscode.window.withProgress(
       { location: vscode.ProgressLocation.Window, title: "Refreshing Codex usage…" },
-      () => provider.refreshUsage(),
+      () => provider.refreshUsage(profile),
     );
   } catch (error) {
     output.appendLine(`[usage] refresh failed: ${messageOf(error)}`);
@@ -245,12 +248,17 @@ async function showUsage(provider: OpenAICodexProvider, output: vscode.OutputCha
     matchOnDescription: true,
     matchOnDetail: true,
   });
-  if (picked?.action === "refresh") await showUsage(provider, output);
+  if (picked?.action === "refresh") await showUsage(provider, output, profile);
   else if (picked?.action === "open") await vscode.env.openExternal(vscode.Uri.parse("https://chatgpt.com/codex"));
-  else if (picked?.action === "redeemReset" && picked.resetCreditId) await redeemReset(provider, output, picked.resetCreditId);
+  else if (picked?.action === "redeemReset" && picked.resetCreditId) await redeemReset(provider, output, picked.resetCreditId, profile);
 }
 
-async function redeemReset(provider: OpenAICodexProvider, output: vscode.OutputChannel, creditId: string): Promise<void> {
+async function redeemReset(
+  provider: OpenAICodexProvider,
+  output: vscode.OutputChannel,
+  creditId: string,
+  profile: string,
+): Promise<void> {
   const confirmation = await vscode.window.showWarningMessage(
     "Redeem this Codex reset credit? It resets both the 5-hour and weekly usage windows and consumes one banked reset.",
     { modal: true },
@@ -260,7 +268,7 @@ async function redeemReset(provider: OpenAICodexProvider, output: vscode.OutputC
   try {
     const result = await vscode.window.withProgress(
       { location: vscode.ProgressLocation.Window, title: "Redeeming Codex reset credit…" },
-      () => provider.consumeResetCredit(creditId),
+      () => provider.consumeResetCredit(creditId, profile),
     );
     const messages: Record<string, string> = {
       alreadyRedeemed: "This Codex reset request was already redeemed.",
@@ -273,7 +281,7 @@ async function redeemReset(provider: OpenAICodexProvider, output: vscode.OutputC
     } else if (result.outcome === "alreadyRedeemed") vscode.window.showInformationMessage(messages[result.outcome]);
     else if (messages[result.outcome]) vscode.window.showWarningMessage(messages[result.outcome]);
     else vscode.window.showWarningMessage(`Codex reset response: ${result.outcome}`);
-    await showUsage(provider, output);
+    await showUsage(provider, output, profile);
   } catch (error) {
     showError("Codex reset credit redemption failed", error, output);
   }

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,7 +1,7 @@
 /** User-facing Codex Bridge command registration and workflows. */
 
 import * as vscode from "vscode";
-import { type AuthorizationFlow, OpenAIOAuth } from "../auth/auth";
+import { DEFAULT_OAUTH_PROFILE, normalizeProfileId, type AuthorizationFlow, OpenAIOAuth } from "../auth/auth";
 import { messageOf } from "../errors";
 import { OpenAICodexProvider } from "../provider";
 import { EXTENSION_DISPLAY_NAME } from "../transport/protocol";
@@ -15,6 +15,8 @@ export function registerCodexCommands(
 ): vscode.Disposable[] {
   return [
     vscode.commands.registerCommand("openaiCodex.manage", () => manage(oauth, provider, output, usageStatus)),
+    vscode.commands.registerCommand("openaiCodex.addAccount", () => addAccount(oauth, provider, output)),
+    vscode.commands.registerCommand("openaiCodex.selectProfile", () => selectProfile(oauth, provider)),
     vscode.commands.registerCommand("openaiCodex.signIn", () => browserSignIn(oauth, provider, output)),
     vscode.commands.registerCommand("openaiCodex.signInManual", () => manualSignIn(oauth, provider, output)),
     vscode.commands.registerCommand("openaiCodex.importCodexSession", () => importCodexSession(oauth, provider, output)),
@@ -31,41 +33,53 @@ async function manage(
   output: vscode.OutputChannel,
   usageStatus: vscode.StatusBarItem,
 ): Promise<void> {
-  const session = await oauth.sessionInfo();
+  const profile = provider.getActiveProfile();
+  const session = await oauth.sessionInfo(profile);
   const picked = await vscode.window.showQuickPick(session ? [
+    { label: "$(account) Switch profile", action: "switch" },
+    { label: "$(add) Add ChatGPT account", action: "add" },
     { label: "$(pulse) Show Codex usage", action: "usage" },
     { label: "$(check) Test Codex connection", action: "test" },
     { label: "$(refresh) Refresh Codex models", action: "refresh" },
     { label: "$(output) Show Codex Bridge logs", action: "logs" },
     { label: "$(sign-out) Sign out of Codex Bridge", action: "signout" },
   ] : [
-    { label: "$(globe) Sign in with ChatGPT", action: "signin", description: "ChatGPT Plus or Pro" },
+    { label: "$(globe) Sign in with ChatGPT", action: "signin", description: `Profile: ${profile}` },
+    { label: "$(account) Switch profile", action: "switch" },
+    { label: "$(add) Add ChatGPT account", action: "add" },
     { label: "$(link) Sign in manually", action: "manual", description: "Use if localhost:1455 is unavailable" },
     { label: "$(terminal) Import Codex CLI session (Advanced)", action: "import", description: "Copies OAuth credentials from ~/.codex/auth.json" },
     { label: "$(output) Show Codex Bridge logs", action: "logs" },
-  ], { title: `Codex Bridge — ${session?.email ?? (session ? "signed in" : "not signed in")}` });
+  ], { title: `Codex Bridge [${profile}] — ${session?.email ?? (session ? "signed in" : "not signed in")}` });
   if (!picked) return;
-  if (picked.action === "signin") await browserSignIn(oauth, provider, output);
-  else if (picked.action === "manual") await manualSignIn(oauth, provider, output);
-  else if (picked.action === "import") await importCodexSession(oauth, provider, output);
+  if (picked.action === "signin") await browserSignIn(oauth, provider, output, profile);
+  else if (picked.action === "switch") await selectProfile(oauth, provider);
+  else if (picked.action === "add") await addAccount(oauth, provider, output);
+  else if (picked.action === "manual") await manualSignIn(oauth, provider, output, profile);
+  else if (picked.action === "import") await importCodexSession(oauth, provider, output, profile);
   else if (picked.action === "usage") await showUsage(provider, output);
   else if (picked.action === "test") await testConnection(provider, output);
   else if (picked.action === "refresh") await refreshModels(provider, output);
   else if (picked.action === "logs") output.show(true);
   else if (picked.action === "signout") {
-    await oauth.signOut();
-    provider.clearModelCache();
-    provider.clearUsage();
+    await oauth.signOut(profile);
+    provider.clearModelCache(profile);
+    provider.clearUsage(profile);
     usageStatus.hide();
     provider.fireDidChange();
-    vscode.window.showInformationMessage("Signed out of Codex Bridge.");
+    vscode.window.showInformationMessage(`Signed out of Codex Bridge profile “${profile}”.`);
   }
 }
 
-async function browserSignIn(oauth: OpenAIOAuth, provider: OpenAICodexProvider, output: vscode.OutputChannel): Promise<void> {
+async function browserSignIn(
+  oauth: OpenAIOAuth,
+  provider: OpenAICodexProvider,
+  output: vscode.OutputChannel,
+  profile = DEFAULT_OAUTH_PROFILE,
+): Promise<void> {
   let attempt: Awaited<ReturnType<OpenAIOAuth["startBrowserSignIn"]>> | undefined;
   try {
-    attempt = await oauth.startBrowserSignIn();
+    attempt = await oauth.startBrowserSignIn(profile);
     if (!await vscode.env.openExternal(vscode.Uri.parse(attempt.url))) throw new Error("VS Code could not open the OpenAI authorization page");
     await vscode.window.withProgress(
       { location: vscode.ProgressLocation.Notification, title: "Waiting for OpenAI sign-in…", cancellable: true },
@@ -74,17 +88,23 @@ async function browserSignIn(oauth: OpenAIOAuth, provider: OpenAICodexProvider, 
         try { await attempt?.completion; } finally { listener.dispose(); }
       },
     );
-    provider.clearModelCache();
+    provider.setActiveProfile(profile);
+    provider.clearModelCache(profile);
     provider.fireDidChange();
-    refreshUsageAfterAuth(provider, output, "post-sign-in");
-    vscode.window.showInformationMessage("Signed in to Codex Bridge with ChatGPT.");
+    refreshUsageAfterAuth(provider, output, "post-sign-in", profile);
+    vscode.window.showInformationMessage(`Signed in to Codex Bridge profile “${profile}” with ChatGPT.`);
   } catch (error) {
     attempt?.cancel();
     showError("ChatGPT sign-in failed", error, output);
   }
 }
 
-async function manualSignIn(oauth: OpenAIOAuth, provider: OpenAICodexProvider, output: vscode.OutputChannel): Promise<void> {
+async function manualSignIn(
+  oauth: OpenAIOAuth,
+  provider: OpenAICodexProvider,
+  output: vscode.OutputChannel,
+  profile = DEFAULT_OAUTH_PROFILE,
+): Promise<void> {
   const flow: AuthorizationFlow = oauth.createAuthorizationFlow();
   try {
     await vscode.env.clipboard.writeText(flow.url);
@@ -95,17 +115,23 @@ async function manualSignIn(oauth: OpenAIOAuth, provider: OpenAICodexProvider, o
       ignoreFocusOut: true,
     });
     if (!callback) return;
-    await oauth.completeAuthorization(callback, flow);
-    provider.clearModelCache();
+    await oauth.completeAuthorization(callback, flow, profile);
+    provider.setActiveProfile(profile);
+    provider.clearModelCache(profile);
     provider.fireDidChange();
-    refreshUsageAfterAuth(provider, output, "post-sign-in");
-    vscode.window.showInformationMessage("Signed in to Codex Bridge with ChatGPT.");
+    refreshUsageAfterAuth(provider, output, "post-sign-in", profile);
+    vscode.window.showInformationMessage(`Signed in to Codex Bridge profile “${profile}” with ChatGPT.`);
   } catch (error) {
     showError("ChatGPT manual sign-in failed", error, output);
   }
 }
 
-async function importCodexSession(oauth: OpenAIOAuth, provider: OpenAICodexProvider, output: vscode.OutputChannel): Promise<void> {
+async function importCodexSession(
+  oauth: OpenAIOAuth,
+  provider: OpenAICodexProvider,
+  output: vscode.OutputChannel,
+  profile = DEFAULT_OAUTH_PROFILE,
+): Promise<void> {
   try {
     const confirmed = await vscode.window.showWarningMessage(
       "Importing a Codex CLI session copies its OAuth access and refresh credentials into VS Code Secret Storage. A fresh ChatGPT sign-in is recommended.",
@@ -113,14 +139,63 @@ async function importCodexSession(oauth: OpenAIOAuth, provider: OpenAICodexProvi
       "Import session",
     );
     if (confirmed !== "Import session") return;
-    const session = await oauth.importCodexCliSession();
-    provider.clearModelCache();
+    const session = await oauth.importCodexCliSession(profile);
+    provider.setActiveProfile(profile);
+    provider.clearModelCache(profile);
     provider.fireDidChange();
-    refreshUsageAfterAuth(provider, output, "post-import");
-    vscode.window.showInformationMessage(`Imported Codex CLI session${session.email ? ` for ${session.email}` : ""}.`);
+    refreshUsageAfterAuth(provider, output, "post-import", profile);
+    vscode.window.showInformationMessage(`Imported Codex CLI session${session.email ? ` for ${session.email}` : ""} into profile “${profile}”.`);
   } catch (error) {
     showError("Unable to import Codex CLI session", error, output);
   }
+}
+
+async function addAccount(oauth: OpenAIOAuth, provider: OpenAICodexProvider, output: vscode.OutputChannel): Promise<void> {
+  const profile = await promptProfileId();
+  if (!profile) return;
+  if (await oauth.hasSession(profile)) {
+    const replace = await vscode.window.showWarningMessage(
+      `Replace the ChatGPT session stored for profile “${profile}”?`,
+      { modal: true },
+      "Replace",
+    );
+    if (replace !== "Replace") return;
+  }
+  await browserSignIn(oauth, provider, output, profile);
+  if (await oauth.hasSession(profile)) {
+    vscode.window.showInformationMessage(`Add Codex Bridge in Chat: Manage Language Models and enter profile “${profile}”.`);
+  }
+}
+
+async function selectProfile(oauth: OpenAIOAuth, provider: OpenAICodexProvider): Promise<void> {
+  const profiles = await oauth.listProfiles();
+  if (!profiles.length) {
+    vscode.window.showInformationMessage("No Codex Bridge profiles are signed in yet.");
+    return;
+  }
+  const picked = await vscode.window.showQuickPick(
+    await Promise.all(profiles.map(async (profile) => {
+      const session = await oauth.sessionInfo(profile);
+      return { label: profile, description: session?.email ?? "Signed in", profile };
+    })),
+    { title: "Select the active Codex Bridge profile" },
+  );
+  if (!picked) return;
+  provider.setActiveProfile(picked.profile);
+  vscode.window.showInformationMessage(`Codex Bridge profile “${picked.profile}” is now active for usage and management commands.`);
+}
+
+async function promptProfileId(): Promise<string | undefined> {
+  const value = await vscode.window.showInputBox({
+    title: "Add ChatGPT account",
+    prompt: "Choose the profile ID you will enter when adding Codex Bridge in Manage Language Models.",
+    placeHolder: "personal or work",
+    ignoreFocusOut: true,
+    validateInput: (input) => {
+      try { normalizeProfileId(input); return undefined; } catch (error) { return messageOf(error); }
+    },
+  });
+  return value ? normalizeProfileId(value) : undefined;
 }
 
 async function testConnection(provider: OpenAICodexProvider, output: vscode.OutputChannel): Promise<void> {
@@ -149,6 +224,7 @@ async function refreshModels(provider: OpenAICodexProvider, output: vscode.Outpu
 }
 
 async function showUsage(provider: OpenAICodexProvider, output: vscode.OutputChannel): Promise<void> {
+  const profile = provider.getActiveProfile();
   let snapshot = provider.getUsageSnapshot();
   try {
     snapshot = await vscode.window.withProgress(
@@ -164,7 +240,7 @@ async function showUsage(provider: OpenAICodexProvider, output: vscode.OutputCha
     { label: "$(refresh) Refresh usage", action: "refresh", alwaysShow: true },
     { label: "$(link-external) Open ChatGPT Codex", action: "open", alwaysShow: true },
   ], {
-    title: snapshot.updatedAt ? `Codex usage — updated ${new Date(snapshot.updatedAt).toLocaleTimeString()}` : "Codex usage",
+    title: snapshot.updatedAt ? `Codex usage [${profile}] — updated ${new Date(snapshot.updatedAt).toLocaleTimeString()}` : `Codex usage [${profile}]`,
     placeHolder: "Subscription quota and locally tracked inference tokens",
     matchOnDescription: true,
     matchOnDetail: true,
@@ -218,19 +294,19 @@ function toUsageQuickPickItem(row: UsageDisplayRow): UsageQuickPickItem {
 
 async function diagnostics(oauth: OpenAIOAuth, output: vscode.OutputChannel): Promise<void> {
   const models = await vscode.lm.selectChatModels({ vendor: "openai-codex" });
-  const session = await oauth.sessionInfo();
+  const profiles = await oauth.listProfiles();
   const content = [
     `# ${EXTENSION_DISPLAY_NAME} diagnostics`, "", `- VS Code: ${vscode.version}`,
-    `- OAuth session: ${session ? "present" : "missing"}`, `- Account identity: ${session ? "redacted" : "unavailable"}`,
+    `- OAuth profiles: ${profiles.length}`, `- Account identities: ${profiles.length ? "redacted" : "unavailable"}`,
     `- Registered models: ${models.length}`, "", ...models.map((model) => `- ${model.id} (${model.maxInputTokens} input tokens)`),
   ].join("\n");
-  output.appendLine(`[diagnostics] session=${Boolean(session)} models=${models.length}`);
+  output.appendLine(`[diagnostics] profiles=${profiles.length} models=${models.length}`);
   const document = await vscode.workspace.openTextDocument({ content, language: "markdown" });
   await vscode.window.showTextDocument(document, vscode.ViewColumn.Beside);
 }
 
-function refreshUsageAfterAuth(provider: OpenAICodexProvider, output: vscode.OutputChannel, source: string): void {
-  void provider.refreshUsage().catch((error) => output.appendLine(`[usage] ${source} refresh failed: ${messageOf(error)}`));
+function refreshUsageAfterAuth(provider: OpenAICodexProvider, output: vscode.OutputChannel, source: string, profile: string): void {
+  void provider.refreshUsage(profile).catch((error) => output.appendLine(`[usage] ${source} refresh failed: ${messageOf(error)}`));
 }
 
 function showError(prefix: string, error: unknown, output: vscode.OutputChannel): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,23 +1,26 @@
 import * as vscode from "vscode";
 import { messageOf } from "./errors";
-import { OpenAIOAuth } from "./auth/auth";
+import { DEFAULT_OAUTH_PROFILE, OpenAIOAuth } from "./auth/auth";
 import { registerCodexCommands } from "./commands/commands";
 import { OpenAICodexProvider } from "./provider";
 import { EXTENSION_DISPLAY_NAME, extensionUserAgent } from "./transport/protocol";
 import { formatUsageStatusBar, formatUsageTooltip } from "./usage/presentation";
 import { usageSnapshotForPersistence, type CodexUsageSnapshot } from "./usage/domain";
 
-const USAGE_STATE_KEY = "openaiCodex.usageSnapshot.v1";
+const LEGACY_USAGE_STATE_KEY = "openaiCodex.usageSnapshot.v1";
+const USAGE_STATE_KEY = "openaiCodex.usageSnapshots.v2";
 
 export function activate(context: vscode.ExtensionContext): void {
   const output = vscode.window.createOutputChannel("Codex Bridge");
   const oauth = new OpenAIOAuth(context.secrets);
   const version = context.extension.packageJSON.version as string;
+  const storedUsage = context.globalState.get<Readonly<Record<string, CodexUsageSnapshot>>>(USAGE_STATE_KEY)
+    ?? { [DEFAULT_OAUTH_PROFILE]: context.globalState.get<CodexUsageSnapshot>(LEGACY_USAGE_STATE_KEY) ?? {} };
   const provider = new OpenAICodexProvider(
     oauth,
     output,
     extensionUserAgent(version, vscode.version),
-    context.globalState.get<CodexUsageSnapshot>(USAGE_STATE_KEY) ?? {},
+    storedUsage,
     context.globalState,
   );
   const usageStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 91);
@@ -28,10 +31,11 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     output,
     usageStatus,
-    provider.onDidChangeUsage((usage) => {
-      renderUsageStatus(usageStatus, usage);
+    provider.onDidChangeUsage(({ profile, usage }) => {
+      if (profile === provider.getActiveProfile()) renderUsageStatus(usageStatus, usage);
       updateUsageStatusVisibility(usageStatus);
-      void context.globalState.update(USAGE_STATE_KEY, usageSnapshotForPersistence(usage));
+      const persisted = Object.fromEntries(Object.entries(provider.getUsageSnapshots()).map(([key, value]) => [key, usageSnapshotForPersistence(value)]));
+      void context.globalState.update(USAGE_STATE_KEY, persisted);
     }),
     vscode.lm.registerLanguageModelChatProvider("openai-codex", provider),
     ...registerCodexCommands(oauth, provider, output, usageStatus),

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("declares native named profile configuration without a management-command override", () => {
+  const manifest = JSON.parse(readFileSync("package.json", "utf8")) as {
+    contributes: { languageModelChatProviders: Array<Record<string, unknown>> };
+  };
+  const provider = manifest.contributes.languageModelChatProviders.find((item) => item.vendor === "openai-codex");
+  assert.ok(provider);
+  assert.equal(provider.managementCommand, undefined);
+  assert.deepEqual((provider.configuration as { required?: string[] }).required, ["profile"]);
+});

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import { profileFromConfiguration, profileQualifiedModelId } from "./provider-profile";
 
 test("declares native named profile configuration without a management-command override", () => {
   const manifest = JSON.parse(readFileSync("package.json", "utf8")) as {
@@ -10,4 +11,12 @@ test("declares native named profile configuration without a management-command o
   assert.ok(provider);
   assert.equal(provider.managementCommand, undefined);
   assert.deepEqual((provider.configuration as { required?: string[] }).required, ["profile"]);
+});
+
+test("qualifies model IDs by profile and reports invalid native profile values", () => {
+  assert.equal(profileQualifiedModelId("Work", "gpt-5.2"), "work::gpt-5.2");
+  assert.throws(
+    () => profileFromConfiguration({ profile: "work profile" }),
+    /Update this provider entry in Manage Language Models/,
+  );
 });

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -15,6 +15,7 @@ test("declares native named profile configuration without a management-command o
 
 test("qualifies model IDs by profile and reports invalid native profile values", () => {
   assert.equal(profileQualifiedModelId("Work", "gpt-5.2"), "work::gpt-5.2");
+  assert.equal(profileQualifiedModelId("default", "gpt-5.2"), "gpt-5.2");
   assert.throws(
     () => profileFromConfiguration({ profile: "work profile" }),
     /Update this provider entry in Manage Language Models/,

--- a/src/provider-profile.ts
+++ b/src/provider-profile.ts
@@ -1,0 +1,14 @@
+import { DEFAULT_OAUTH_PROFILE, normalizeProfileId } from "./auth/auth";
+
+export function profileFromConfiguration(configuration: Readonly<Record<string, unknown>> | undefined): string {
+  try {
+    return normalizeProfileId(typeof configuration?.profile === "string" ? configuration.profile : DEFAULT_OAUTH_PROFILE);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid Codex Bridge profile. Update this provider entry in Manage Language Models. ${message}`);
+  }
+}
+
+export function profileQualifiedModelId(profile: string, modelId: string): string {
+  return `${normalizeProfileId(profile)}::${modelId}`;
+}

--- a/src/provider-profile.ts
+++ b/src/provider-profile.ts
@@ -10,5 +10,6 @@ export function profileFromConfiguration(configuration: Readonly<Record<string, 
 }
 
 export function profileQualifiedModelId(profile: string, modelId: string): string {
-  return `${normalizeProfileId(profile)}::${modelId}`;
+  const normalized = normalizeProfileId(profile);
+  return normalized === DEFAULT_OAUTH_PROFILE ? modelId : `${normalized}::${modelId}`;
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -200,7 +200,7 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     } catch (error) {
       const message = messageOf(error);
       this.output.appendLine(`[models] ${message}`);
-      void vscode.window.showErrorMessage(message);
+      if (!options.silent) void vscode.window.showErrorMessage(message);
       return [];
     }
     if (!await this.oauth.hasSession(profile)) return [];

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -34,6 +34,7 @@ import {
 import { CodexTransport } from "./transport/client";
 import { CatalogCache } from "./models/catalog-cache";
 import { ModelsDevMetadata, type MetadataCache } from "./models/metadata";
+import { profileFromConfiguration, profileQualifiedModelId } from "./provider-profile";
 
 /** Live model information registered with VS Code Chat. */
 export interface CodexModel extends vscode.LanguageModelChatInformation {
@@ -135,7 +136,6 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
   }
 
   async refreshUsage(profile = this.activeProfile): Promise<CodexUsageSnapshot> {
-    this.activeProfile = profile;
     try {
       const response = await this.transport.sendUsage(profile);
       if (!response.ok) throw await responseError("Unable to refresh OpenAI Codex usage", response);
@@ -201,7 +201,7 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
       const optionSpec = modelOptionSpec(model);
       const defaults = resolveRequestOptions(optionSpec, model.speedMode, undefined);
       return {
-        id: model.registrationId,
+        id: profileQualifiedModelId(profile, model.registrationId),
         rawModelId: model.rawModelId,
         profile,
         name: model.name,
@@ -213,6 +213,7 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
         maxOutputTokens: model.output,
         isUserSelectable: true,
         isBYOK: true,
+        requiresAuthorization: { label: `Codex Bridge (${profile})` },
         configurationSchema: buildModelConfigurationSchema(optionSpec, defaults),
         capabilities: { imageInput: model.image, toolCalling: model.toolCalling },
         speedMode: model.speedMode,
@@ -229,7 +230,6 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
     token: vscode.CancellationToken,
   ): Promise<void> {
-    this.activeProfile = model.profile;
     const requestOptions = resolveRequestOptions(model.optionSpec, model.speedMode, options.modelConfiguration);
     const body = buildRequest(
       model.rawModelId,
@@ -321,10 +321,6 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     this.usageEmitter.fire({ profile, usage });
   }
 
-}
-
-export function profileFromConfiguration(configuration: Readonly<Record<string, unknown>> | undefined): string {
-  return normalizeProfileId(typeof configuration?.profile === "string" ? configuration.profile : DEFAULT_OAUTH_PROFILE);
 }
 
 function memoryMetadataCache(): MetadataCache {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -194,7 +194,15 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
   ): Promise<CodexModel[]> {
     if (token.isCancellationRequested) return [];
     if (!options.configuration) return [];
-    const profile = profileFromConfiguration(options.configuration);
+    let profile: string;
+    try {
+      profile = profileFromConfiguration(options.configuration);
+    } catch (error) {
+      const message = messageOf(error);
+      this.output.appendLine(`[models] ${message}`);
+      void vscode.window.showErrorMessage(message);
+      return [];
+    }
     if (!await this.oauth.hasSession(profile)) return [];
     const models = expandCodexModelVariants(await this.fetchModels(token, profile));
     return models.map((model) => {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -18,7 +18,7 @@ import {
   parseCodexModelsPayload,
   type CodexModelMetadata,
 } from "./models/catalog";
-import { OpenAIOAuth } from "./auth/auth";
+import { DEFAULT_OAUTH_PROFILE, normalizeProfileId, OpenAIOAuth } from "./auth/auth";
 import { partText } from "./provider/messages";
 import { buildRequest } from "./provider/request";
 import { consumeStream } from "./provider/response";
@@ -38,6 +38,7 @@ import { ModelsDevMetadata, type MetadataCache } from "./models/metadata";
 /** Live model information registered with VS Code Chat. */
 export interface CodexModel extends vscode.LanguageModelChatInformation {
   rawModelId: string;
+  profile: string;
   speedMode: SpeedMode;
   optionSpec: ModelOptionSpec;
   supportsParallelToolCalls: boolean;
@@ -57,13 +58,14 @@ export interface CodexModel extends vscode.LanguageModelChatInformation {
  */
 export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<CodexModel> {
   private readonly changeEmitter = new vscode.EventEmitter<void>();
-  private readonly usageEmitter = new vscode.EventEmitter<CodexUsageSnapshot>();
+  private readonly usageEmitter = new vscode.EventEmitter<{ profile: string; usage: CodexUsageSnapshot }>();
   readonly onDidChangeLanguageModelChatInformation = this.changeEmitter.event;
   readonly onDidChangeUsage = this.usageEmitter.event;
-  private usage: CodexUsageSnapshot;
-  private lastQuotaFetchAt = 0;
-  private readonly modelCache = new CatalogCache<CodexModelMetadata[]>();
-  private modelCacheAccount: string | undefined;
+  private readonly usageByProfile = new Map<string, CodexUsageSnapshot>();
+  private readonly lastQuotaFetchAt = new Map<string, number>();
+  private readonly modelCaches = new Map<string, CatalogCache<CodexModelMetadata[]>>();
+  private readonly modelCacheAccounts = new Map<string, string>();
+  private activeProfile = DEFAULT_OAUTH_PROFILE;
   private readonly transport: CodexTransport;
   private readonly metadata: ModelsDevMetadata;
 
@@ -71,11 +73,11 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     private readonly oauth: OpenAIOAuth,
     private readonly output: vscode.OutputChannel,
     userAgent: string,
-    initialUsage: CodexUsageSnapshot = {},
+    initialUsage: Readonly<Record<string, CodexUsageSnapshot>> = {},
     metadataCache: MetadataCache = memoryMetadataCache(),
     fetcher: typeof fetch = fetch,
   ) {
-    this.usage = initialUsage;
+    for (const [profile, usage] of Object.entries(initialUsage)) this.usageByProfile.set(profile, usage);
     this.transport = new CodexTransport(
       oauth,
       userAgent,
@@ -89,16 +91,21 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     this.changeEmitter.fire();
   }
 
-  clearModelCache(): void {
-    this.modelCache.clear();
-    this.modelCacheAccount = undefined;
+  clearModelCache(profile?: string): void {
+    if (profile) {
+      this.modelCaches.get(profile)?.clear();
+      this.modelCacheAccounts.delete(profile);
+      return;
+    }
+    for (const cache of this.modelCaches.values()) cache.clear();
+    this.modelCacheAccounts.clear();
   }
 
-  async refreshModels(): Promise<number> {
-    this.clearModelCache();
+  async refreshModels(profile = this.activeProfile): Promise<number> {
+    this.clearModelCache(profile);
     const cancellation = new vscode.CancellationTokenSource();
     try {
-      const models = await this.fetchModels(cancellation.token);
+      const models = await this.fetchModels(cancellation.token, profile);
       this.fireDidChange();
       return expandCodexModelVariants(models).length;
     } finally {
@@ -106,23 +113,37 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     }
   }
 
-  getUsageSnapshot(): CodexUsageSnapshot {
-    return this.usage;
+  getActiveProfile(): string {
+    return this.activeProfile;
   }
 
-  clearUsage(): void {
-    this.setUsage({});
+  setActiveProfile(profile: string): void {
+    this.activeProfile = normalizeProfileId(profile);
+    this.usageEmitter.fire({ profile: this.activeProfile, usage: this.getUsageSnapshot() });
   }
 
-  async refreshUsage(): Promise<CodexUsageSnapshot> {
+  getUsageSnapshot(profile = this.activeProfile): CodexUsageSnapshot {
+    return this.usageByProfile.get(profile) ?? {};
+  }
+
+  getUsageSnapshots(): Readonly<Record<string, CodexUsageSnapshot>> {
+    return Object.fromEntries(this.usageByProfile);
+  }
+
+  clearUsage(profile = this.activeProfile): void {
+    this.setUsage(profile, {});
+  }
+
+  async refreshUsage(profile = this.activeProfile): Promise<CodexUsageSnapshot> {
+    this.activeProfile = profile;
     try {
-      const response = await this.transport.sendUsage();
+      const response = await this.transport.sendUsage(profile);
       if (!response.ok) throw await responseError("Unable to refresh OpenAI Codex usage", response);
       const updatedAt = Date.now();
-      this.lastQuotaFetchAt = updatedAt;
-      let next = mergeQuotaPayload(this.usage, await response.json(), updatedAt);
+      this.lastQuotaFetchAt.set(profile, updatedAt);
+      let next = mergeQuotaPayload(this.getUsageSnapshot(profile), await response.json(), updatedAt);
       try {
-        const resetCreditsResponse = await this.transport.sendResetCredits();
+        const resetCreditsResponse = await this.transport.sendResetCredits(profile);
         if (!resetCreditsResponse.ok) {
           next = { ...next, resetCredits: undefined, resetCreditsError: "The Codex backend did not provide reset-credit details" };
         } else {
@@ -132,23 +153,23 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
         // Reset-credit details are optional; quota refresh remains useful when this private endpoint changes.
         next = { ...next, resetCredits: undefined, resetCreditsError: "Reset-credit details could not be refreshed" };
       }
-      this.setUsage(next);
-      return this.usage;
+      this.setUsage(profile, next);
+      return next;
     } catch (error) {
-      this.setUsage({ ...this.usage, error: messageOf(error), updatedAt: Date.now() });
+      this.setUsage(profile, { ...this.getUsageSnapshot(profile), error: messageOf(error), updatedAt: Date.now() });
       throw error;
     }
   }
 
-  async consumeResetCredit(creditId: string): Promise<{ outcome: string; windowsReset?: number }> {
+  async consumeResetCredit(creditId: string, profile = this.activeProfile): Promise<{ outcome: string; windowsReset?: number }> {
     const redeemRequestId = randomUUID();
     const response = await this.transport.sendResetCreditConsume((accountId) => JSON.stringify(
       buildResetCreditConsumePayload(creditId, redeemRequestId, accountId),
-    ));
+    ), profile);
     if (!response.ok) throw await responseError("Unable to redeem OpenAI Codex reset credit", response);
     const result = parseResetCreditConsumePayload(await response.json());
     try {
-      await this.refreshUsage();
+      await this.refreshUsage(profile);
     } catch {
       // The redemption result is authoritative even if the follow-up snapshot is temporarily unavailable.
     }
@@ -168,25 +189,30 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
    * @see {@link expandCodexModelVariants}
    */
   async provideLanguageModelChatInformation(
-    _options: vscode.PrepareLanguageModelChatModelOptions,
+    options: vscode.PrepareLanguageModelChatModelOptions,
     token: vscode.CancellationToken,
   ): Promise<CodexModel[]> {
     if (token.isCancellationRequested) return [];
-    const models = expandCodexModelVariants(await this.fetchModels(token));
+    if (!options.configuration) return [];
+    const profile = profileFromConfiguration(options.configuration);
+    if (!await this.oauth.hasSession(profile)) return [];
+    const models = expandCodexModelVariants(await this.fetchModels(token, profile));
     return models.map((model) => {
       const optionSpec = modelOptionSpec(model);
       const defaults = resolveRequestOptions(optionSpec, model.speedMode, undefined);
       return {
         id: model.registrationId,
         rawModelId: model.rawModelId,
+        profile,
         name: model.name,
         family: model.rawModelId,
         version: model.version,
-        detail: model.detail,
+        detail: `${model.detail} · ${profile}`,
         tooltip: model.description,
         maxInputTokens: model.input,
         maxOutputTokens: model.output,
         isUserSelectable: true,
+        isBYOK: true,
         configurationSchema: buildModelConfigurationSchema(optionSpec, defaults),
         capabilities: { imageInput: model.image, toolCalling: model.toolCalling },
         speedMode: model.speedMode,
@@ -203,6 +229,7 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
     token: vscode.CancellationToken,
   ): Promise<void> {
+    this.activeProfile = model.profile;
     const requestOptions = resolveRequestOptions(model.optionSpec, model.speedMode, options.modelConfiguration);
     const body = buildRequest(
       model.rawModelId,
@@ -212,16 +239,16 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
       model.supportsParallelToolCalls,
       model.optionSpec.supportsReasoningSummaryParameter,
     );
-    const response = await this.transport.sendResponse(body, token);
+    const response = await this.transport.sendResponse(body, token, model.profile);
     if (!response.ok) throw await responseError(`OpenAI Codex request failed for ${model.rawModelId}`, response);
     if (!response.body) throw new Error("OpenAI Codex returned an empty response stream");
 
     if (configuration().get("debugLogging", false)) {
       this.output.appendLine(`[request] model=${model.rawModelId} speed=${requestOptions.speedMode} effort=${requestOptions.reasoningEffort} summary=${requestOptions.reasoningSummary} webSearch=${requestOptions.webSearch} imageGeneration=${requestOptions.imageGeneration} initiator=${options.requestInitiator ?? "unknown"}`);
     }
-    await consumeStream(response.body, progress, token, (usage) => this.captureRequestUsage(usage, model.rawModelId));
-    if (Date.now() - this.lastQuotaFetchAt > 60_000) {
-      void this.refreshUsage().catch((error) => this.output.appendLine(`[usage] refresh failed: ${messageOf(error)}`));
+    await consumeStream(response.body, progress, token, (usage) => this.captureRequestUsage(usage, model.rawModelId, model.profile));
+    if (Date.now() - (this.lastQuotaFetchAt.get(model.profile) ?? 0) > 60_000) {
+      void this.refreshUsage(model.profile).catch((error) => this.output.appendLine(`[usage] refresh failed: ${messageOf(error)}`));
     }
   }
 
@@ -234,10 +261,10 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     return Math.max(1, Math.ceil(text.length / 4));
   }
 
-  async testConnection(): Promise<{ model: string; text: string; speedMode: string; reasoningEffort: string; reasoningSummary: string }> {
+  async testConnection(profile = this.activeProfile): Promise<{ model: string; text: string; speedMode: string; reasoningEffort: string; reasoningSummary: string }> {
     const cancellation = new vscode.CancellationTokenSource();
     try {
-      const model = (await this.fetchModels(cancellation.token))[0];
+      const model = (await this.fetchModels(cancellation.token, profile))[0];
       const requestOptions = resolveRequestOptions(modelOptionSpec(model), "normal", undefined);
       const body = applyModelRequestOptions({
         model: model.id,
@@ -247,50 +274,57 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
         stream: true,
         include: ["reasoning.encrypted_content"],
       }, requestOptions, model.supportsReasoningSummaryParameter);
-      const response = await this.transport.sendResponse(body, cancellation.token);
+      const response = await this.transport.sendResponse(body, cancellation.token, profile);
       if (!response.ok) throw await responseError("OpenAI Codex connection test failed", response);
       if (!response.body) throw new Error("OpenAI Codex returned an empty response stream");
       const text: string[] = [];
       await consumeStream(response.body, { report: (part) => {
         if (part instanceof vscode.LanguageModelTextPart) text.push(part.value);
-      } }, cancellation.token, (usage) => this.captureRequestUsage(usage, model.id));
+      } }, cancellation.token, (usage) => this.captureRequestUsage(usage, model.id, profile));
       return { model: model.id, text: text.join("").trim() || "(empty response)", ...requestOptions };
     } finally {
       cancellation.dispose();
     }
   }
 
-  private async fetchModels(cancellation: vscode.CancellationToken): Promise<CodexModelMetadata[]> {
+  private async fetchModels(cancellation: vscode.CancellationToken, profile: string): Promise<CodexModelMetadata[]> {
     const maxAge = Math.max(1, configuration().get("catalogCacheMinutes", 5)) * 60_000;
-    const session = await this.oauth.sessionInfo();
+    const session = await this.oauth.sessionInfo(profile);
     const account = session?.accountId ?? session?.email;
-    if (!account || account !== this.modelCacheAccount) this.clearModelCache();
-    const models = await this.modelCache.getOrRefresh(maxAge, async () => {
-      const response = await this.transport.sendModels(cancellation);
+    if (!account) throw new Error(`Sign in to OpenAI Codex profile “${profile}” first`);
+    if (account !== this.modelCacheAccounts.get(profile)) this.clearModelCache(profile);
+    const cache = this.modelCaches.get(profile) ?? new CatalogCache<CodexModelMetadata[]>();
+    this.modelCaches.set(profile, cache);
+    const models = await cache.getOrRefresh(maxAge, async () => {
+      const response = await this.transport.sendModels(cancellation, profile);
       if (!response.ok) throw await responseError("Unable to load OpenAI Codex models", response);
       const parsed = parseCodexModelsPayload(await response.json());
       if (!parsed.length) throw new Error("OpenAI Codex returned no usable models");
       const metadata = await this.metadata.getOrRefresh();
       return parsed.map((model) => enrichCodexModel(model, metadata.models[model.id]));
     }, () => cancellation.isCancellationRequested);
-    this.modelCacheAccount = account;
+    this.modelCacheAccounts.set(profile, account);
     return models;
   }
 
-  private captureRequestUsage(raw: Record<string, unknown>, modelId: string): void {
+  private captureRequestUsage(raw: Record<string, unknown>, modelId: string, profile: string): void {
     const payload = toProviderUsagePayload(raw);
     if (!payload) return;
     if (configuration().get("debugLogging", false)) {
       this.output.appendLine(`[usage] model=${modelId} ${JSON.stringify(payload)}`);
     }
-    this.setUsage(recordRequestUsage(this.usage, raw, modelId));
+    this.setUsage(profile, recordRequestUsage(this.getUsageSnapshot(profile), raw, modelId));
   }
 
-  private setUsage(usage: CodexUsageSnapshot): void {
-    this.usage = usage;
-    this.usageEmitter.fire(usage);
+  private setUsage(profile: string, usage: CodexUsageSnapshot): void {
+    this.usageByProfile.set(profile, usage);
+    this.usageEmitter.fire({ profile, usage });
   }
 
+}
+
+export function profileFromConfiguration(configuration: Readonly<Record<string, unknown>> | undefined): string {
+  return normalizeProfileId(typeof configuration?.profile === "string" ? configuration.profile : DEFAULT_OAUTH_PROFILE);
 }
 
 function memoryMetadataCache(): MetadataCache {

--- a/src/transport/client.ts
+++ b/src/transport/client.ts
@@ -3,6 +3,7 @@
 import { randomUUID } from "node:crypto";
 import * as vscode from "vscode";
 import type { OpenAIOAuth } from "../auth/auth";
+import { DEFAULT_OAUTH_PROFILE } from "../auth/auth";
 import { createPromptCacheTransportHeaders } from "../features/prompt-cache";
 import {
   CHATGPT_CODEX_RESET_CREDIT_CONSUME_URL,
@@ -24,8 +25,8 @@ export class CodexTransport {
     private readonly fetcher: typeof fetch = fetch,
   ) {}
 
-  sendModels(cancellation: vscode.CancellationToken): Promise<Response> {
-    return this.withAuthRetry((credentials) => this.fetchWithCancellation(chatgptCodexModelsUrl(CODEX_MODELS_CLIENT_VERSION), {
+  sendModels(cancellation: vscode.CancellationToken, profile = DEFAULT_OAUTH_PROFILE): Promise<Response> {
+    return this.withAuthRetry(profile, (credentials) => this.fetchWithCancellation(chatgptCodexModelsUrl(CODEX_MODELS_CLIENT_VERSION), {
       headers: {
         ...this.authHeaders(credentials, "application/json"),
         Originator: OAUTH_ORIGINATOR,
@@ -34,14 +35,14 @@ export class CodexTransport {
     }, cancellation));
   }
 
-  sendUsage(): Promise<Response> {
-    return this.withAuthRetry((credentials) => this.fetcher(CHATGPT_CODEX_USAGE_URL, {
+  sendUsage(profile = DEFAULT_OAUTH_PROFILE): Promise<Response> {
+    return this.withAuthRetry(profile, (credentials) => this.fetcher(CHATGPT_CODEX_USAGE_URL, {
       headers: this.authHeaders(credentials, "application/json"),
     }));
   }
 
-  sendResetCredits(): Promise<Response> {
-    return this.withAuthRetry((credentials) => this.fetcher(CHATGPT_CODEX_RESET_CREDITS_URL, {
+  sendResetCredits(profile = DEFAULT_OAUTH_PROFILE): Promise<Response> {
+    return this.withAuthRetry(profile, (credentials) => this.fetcher(CHATGPT_CODEX_RESET_CREDITS_URL, {
       headers: {
         ...this.authHeaders(credentials, "application/json"),
         Originator: OAUTH_ORIGINATOR,
@@ -50,8 +51,8 @@ export class CodexTransport {
     }));
   }
 
-  sendResetCreditConsume(body: (accountId: string | undefined) => string): Promise<Response> {
-    return this.withAuthRetry((credentials) => this.fetcher(CHATGPT_CODEX_RESET_CREDIT_CONSUME_URL, {
+  sendResetCreditConsume(body: (accountId: string | undefined) => string, profile = DEFAULT_OAUTH_PROFILE): Promise<Response> {
+    return this.withAuthRetry(profile, (credentials) => this.fetcher(CHATGPT_CODEX_RESET_CREDIT_CONSUME_URL, {
       method: "POST",
       headers: {
         ...this.authHeaders(credentials, "application/json"),
@@ -63,8 +64,8 @@ export class CodexTransport {
     }));
   }
 
-  sendResponse(body: Record<string, unknown>, cancellation: vscode.CancellationToken): Promise<Response> {
-    return this.withAuthRetry((credentials) => {
+  sendResponse(body: Record<string, unknown>, cancellation: vscode.CancellationToken, profile = DEFAULT_OAUTH_PROFILE): Promise<Response> {
+    return this.withAuthRetry(profile, (credentials) => {
       const promptCacheKey = typeof body.prompt_cache_key === "string" ? body.prompt_cache_key : undefined;
       const transportHeaders = promptCacheKey
         ? createPromptCacheTransportHeaders(promptCacheKey)
@@ -82,9 +83,12 @@ export class CodexTransport {
     });
   }
 
-  private async withAuthRetry(request: (credentials: OAuthCredentials) => Promise<Response>): Promise<Response> {
-    let response = await request(await this.oauth.getAccessToken());
-    if (response.status === 401) response = await request(await this.oauth.getAccessToken(true));
+  private async withAuthRetry(
+    profile: string,
+    request: (credentials: OAuthCredentials) => Promise<Response>,
+  ): Promise<Response> {
+    let response = await request(await this.oauth.getAccessToken(false, profile));
+    if (response.status === 401) response = await request(await this.oauth.getAccessToken(true, profile));
     return response;
   }
 

--- a/src/vscode/proposed-chat-provider.d.ts
+++ b/src/vscode/proposed-chat-provider.d.ts
@@ -10,6 +10,7 @@ declare module "vscode" {
     readonly isUserSelectable?: boolean;
     readonly configurationSchema?: LanguageModelConfigurationSchema;
     readonly targetChatSessionType?: string;
+    readonly isBYOK?: boolean;
   }
 
   export interface LanguageModelChatCapabilities {


### PR DESCRIPTION
## What changed

- replace the deprecated provider management override with VS Code native named provider configuration
- add isolated ChatGPT OAuth profiles with per-profile refresh, model catalogs, request routing, quota, and local usage state
- add account/profile management commands, migration guidance, tests, and a minor Changeset

## Why

VS Code can create multiple entries for the same language-model provider, but Codex Bridge previously stored one global OAuth session and routed every model through it. Named profiles let work and personal ChatGPT accounts coexist without credential, cache, or usage state leaking between entries.

## Validation

- `npm test` — 66 tests passed
- `npm run package` — VSIX packaging passed
- `git diff --check`

Live OAuth acceptance remains an Extension Development Host check because it requires real ChatGPT accounts.