### PR TITLE
Fix persisted profile management selection

### DIFF
--- a/.changeset/persist-native-profile-management.md
+++ b/.changeset/persist-native-profile-management.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": patch
+---
+
+Restore the selected profile for usage and management after restart, clarify that native model entries retain their own account routing, and keep legacy default entries valid.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,7 +4,7 @@
 
 Run `code --install-extension openai-oauth-copilot-chat-0.1.0.vsix`, then reload VS Code.
 
-Use **Codex Bridge: Add ChatGPT Account** to authenticate and assign the account a profile ID. After sign-in, run **Chat: Manage Language Models**, choose **Add Models → Codex Bridge**, and enter the same profile ID. VS Code keeps each named entry separate, so multiple ChatGPT accounts can coexist in one window.
+Use **Codex Bridge: Add ChatGPT Account** to authenticate and assign the account a profile ID. After sign-in, run **Chat: Manage Language Models**, choose **Add Models → Codex Bridge**, and enter the same profile ID. VS Code keeps each named entry separate, so multiple ChatGPT accounts can coexist in one window. Leaving the profile field empty preserves the legacy `default` account.
 
 The `default` profile preserves an existing single-account session, but after upgrading you must add a Codex Bridge entry in **Chat: Manage Language Models** and use `default` as its profile ID. **Codex Bridge: Select Active Profile** chooses which account the status bar and management commands display; model requests always use the account attached to the selected Language Models entry.
 
@@ -13,7 +13,7 @@ effort controls default to High when the model supports it; otherwise the catalo
 is retained. Models
 that advertise the `fast` additional speed tier expose a native **Speed Mode** control
 with Normal and Fast choices. Selecting Fast requests faster processing with increased
-account usage without adding a separate Fast model entry.
+account usage without adding a separate Fast model entry. The selected **profile for usage and management** is restored after restart; it never changes the account attached to a model entry.
 
 The `openaiCodex.reasoningSummary` setting controls the Responses API
 `reasoning.summary` value. `auto`, `concise`, and `detailed` request the corresponding

--- a/package.json
+++ b/package.json
@@ -158,9 +158,6 @@
         "displayName": "Codex Bridge",
         "configuration": {
           "type": "object",
-          "required": [
-            "profile"
-          ],
           "properties": {
             "profile": {
               "type": "string",

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -36,7 +36,7 @@ async function manage(
   const profile = provider.getActiveProfile();
   const session = await oauth.sessionInfo(profile);
   const picked = await vscode.window.showQuickPick(session ? [
-    { label: "$(account) Switch profile", action: "switch" },
+    { label: "$(account) Select profile for usage and management", action: "switch" },
     { label: "$(add) Add ChatGPT account", action: "add" },
     { label: "$(pulse) Show Codex usage", action: "usage" },
     { label: "$(check) Test Codex connection", action: "test" },
@@ -45,7 +45,7 @@ async function manage(
     { label: "$(sign-out) Sign out of Codex Bridge", action: "signout" },
   ] : [
     { label: "$(globe) Sign in with ChatGPT", action: "signin", description: `Profile: ${profile}` },
-    { label: "$(account) Switch profile", action: "switch" },
+    { label: "$(account) Select profile for usage and management", action: "switch" },
     { label: "$(add) Add ChatGPT account", action: "add" },
     { label: "$(link) Sign in manually", action: "manual", description: "Use if localhost:1455 is unavailable" },
     { label: "$(terminal) Import Codex CLI session (Advanced)", action: "import", description: "Copies OAuth credentials from ~/.codex/auth.json" },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,9 +6,11 @@ import { OpenAICodexProvider } from "./provider";
 import { EXTENSION_DISPLAY_NAME, extensionUserAgent } from "./transport/protocol";
 import { formatUsageStatusBar, formatUsageTooltip } from "./usage/presentation";
 import { usageSnapshotForPersistence, type CodexUsageSnapshot } from "./usage/domain";
+import { activeProfileFromState } from "./provider-profile";
 
 const LEGACY_USAGE_STATE_KEY = "openaiCodex.usageSnapshot.v1";
 const USAGE_STATE_KEY = "openaiCodex.usageSnapshots.v2";
+const ACTIVE_PROFILE_STATE_KEY = "openaiCodex.activeProfile.v1";
 
 export function activate(context: vscode.ExtensionContext): void {
   const output = vscode.window.createOutputChannel("Codex Bridge");
@@ -16,12 +18,15 @@ export function activate(context: vscode.ExtensionContext): void {
   const version = context.extension.packageJSON.version as string;
   const storedUsage = context.globalState.get<Readonly<Record<string, CodexUsageSnapshot>>>(USAGE_STATE_KEY)
     ?? { [DEFAULT_OAUTH_PROFILE]: context.globalState.get<CodexUsageSnapshot>(LEGACY_USAGE_STATE_KEY) ?? {} };
+  const activeProfile = activeProfileFromState(context.globalState.get<unknown>(ACTIVE_PROFILE_STATE_KEY));
   const provider = new OpenAICodexProvider(
     oauth,
     output,
     extensionUserAgent(version, vscode.version),
     storedUsage,
     context.globalState,
+    fetch,
+    activeProfile,
   );
   const usageStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 91);
   usageStatus.name = "Codex Bridge usage";
@@ -31,6 +36,9 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     output,
     usageStatus,
+    provider.onDidChangeActiveProfile((profile) => {
+      void context.globalState.update(ACTIVE_PROFILE_STATE_KEY, profile);
+    }),
     provider.onDidChangeUsage(({ profile, usage }) => {
       if (profile === provider.getActiveProfile()) renderUsageStatus(usageStatus, usage);
       updateUsageStatusVisibility(usageStatus);
@@ -50,7 +58,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }),
   );
   output.appendLine(`[activate] ${EXTENSION_DISPLAY_NAME} ${version} on VS Code ${vscode.version}`);
-  void oauth.hasSession().then((signedIn) => {
+  void oauth.hasSession(provider.getActiveProfile()).then((signedIn) => {
     if (!signedIn) return;
     updateUsageStatusVisibility(usageStatus);
     void provider.refreshUsage().catch((error) => output.appendLine(`[usage] initial refresh failed: ${messageOf(error)}`));

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -1,16 +1,16 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
-import { profileFromConfiguration, profileQualifiedModelId } from "./provider-profile";
+import { activeProfileFromState, profileFromConfiguration, profileQualifiedModelId } from "./provider-profile";
 
-test("declares native named profile configuration without a management-command override", () => {
+test("declares optional native profile configuration without a management-command override", () => {
   const manifest = JSON.parse(readFileSync("package.json", "utf8")) as {
     contributes: { languageModelChatProviders: Array<Record<string, unknown>> };
   };
   const provider = manifest.contributes.languageModelChatProviders.find((item) => item.vendor === "openai-codex");
   assert.ok(provider);
   assert.equal(provider.managementCommand, undefined);
-  assert.deepEqual((provider.configuration as { required?: string[] }).required, ["profile"]);
+  assert.equal((provider.configuration as { required?: string[] }).required, undefined);
 });
 
 test("qualifies model IDs by profile and reports invalid native profile values", () => {
@@ -20,4 +20,10 @@ test("qualifies model IDs by profile and reports invalid native profile values",
     () => profileFromConfiguration({ profile: "work profile" }),
     /Update this provider entry in Manage Language Models/,
   );
+});
+
+test("restores only a valid persisted management profile", () => {
+  assert.equal(activeProfileFromState("Work"), "work");
+  assert.equal(activeProfileFromState("work profile"), "default");
+  assert.equal(activeProfileFromState(undefined), "default");
 });

--- a/src/provider-profile.ts
+++ b/src/provider-profile.ts
@@ -13,3 +13,12 @@ export function profileQualifiedModelId(profile: string, modelId: string): strin
   const normalized = normalizeProfileId(profile);
   return normalized === DEFAULT_OAUTH_PROFILE ? modelId : `${normalized}::${modelId}`;
 }
+
+/** Restores a command-management profile without allowing stale state to prevent activation. */
+export function activeProfileFromState(value: unknown): string {
+  try {
+    return typeof value === "string" ? normalizeProfileId(value) : DEFAULT_OAUTH_PROFILE;
+  } catch {
+    return DEFAULT_OAUTH_PROFILE;
+  }
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -34,7 +34,7 @@ import {
 import { CodexTransport } from "./transport/client";
 import { CatalogCache } from "./models/catalog-cache";
 import { ModelsDevMetadata, type MetadataCache } from "./models/metadata";
-import { profileFromConfiguration, profileQualifiedModelId } from "./provider-profile";
+import { activeProfileFromState, profileFromConfiguration, profileQualifiedModelId } from "./provider-profile";
 
 /** Live model information registered with VS Code Chat. */
 export interface CodexModel extends vscode.LanguageModelChatInformation {
@@ -60,13 +60,15 @@ export interface CodexModel extends vscode.LanguageModelChatInformation {
 export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<CodexModel> {
   private readonly changeEmitter = new vscode.EventEmitter<void>();
   private readonly usageEmitter = new vscode.EventEmitter<{ profile: string; usage: CodexUsageSnapshot }>();
+  private readonly activeProfileEmitter = new vscode.EventEmitter<string>();
   readonly onDidChangeLanguageModelChatInformation = this.changeEmitter.event;
   readonly onDidChangeUsage = this.usageEmitter.event;
+  readonly onDidChangeActiveProfile = this.activeProfileEmitter.event;
   private readonly usageByProfile = new Map<string, CodexUsageSnapshot>();
   private readonly lastQuotaFetchAt = new Map<string, number>();
   private readonly modelCaches = new Map<string, CatalogCache<CodexModelMetadata[]>>();
   private readonly modelCacheAccounts = new Map<string, string>();
-  private activeProfile = DEFAULT_OAUTH_PROFILE;
+  private activeProfile: string;
   private readonly transport: CodexTransport;
   private readonly metadata: ModelsDevMetadata;
 
@@ -77,8 +79,10 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
     initialUsage: Readonly<Record<string, CodexUsageSnapshot>> = {},
     metadataCache: MetadataCache = memoryMetadataCache(),
     fetcher: typeof fetch = fetch,
+    initialActiveProfile: unknown = DEFAULT_OAUTH_PROFILE,
   ) {
     for (const [profile, usage] of Object.entries(initialUsage)) this.usageByProfile.set(profile, usage);
+    this.activeProfile = activeProfileFromState(initialActiveProfile);
     this.transport = new CodexTransport(
       oauth,
       userAgent,
@@ -120,6 +124,7 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
 
   setActiveProfile(profile: string): void {
     this.activeProfile = normalizeProfileId(profile);
+    this.activeProfileEmitter.fire(this.activeProfile);
     this.usageEmitter.fire({ profile: this.activeProfile, usage: this.getUsageSnapshot() });
   }
 


### PR DESCRIPTION
## Summary
- persist the selected profile used by legacy usage and management commands
- clarify that native model entries retain their own account routing
- retain legacy default-profile native entries

## Verification
- npm run check
- npm run package