### PR TITLE
feat: add configurable Codex catalog version

### DIFF
--- a/.changeset/fluffy-moments-scream.md
+++ b/.changeset/fluffy-moments-scream.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": patch
+---
+
+Add an optional Codex model-catalog client version setting.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -34,6 +34,11 @@ not registered.
 reused before the next discovery request. If a refresh fails, the last usable catalog
 remains available.
 
+`openaiCodex.codexVersion` optionally overrides the Codex client version sent while
+loading the live model catalog. Leave it empty (the default) to use the version bundled
+with the extension. Set it only to test a known Codex release version, for example
+`"openaiCodex.codexVersion": "0.149.0"`; changing it clears the catalog cache.
+
 The live Codex directory remains authoritative for availability, limits, capabilities,
 and reasoning levels. The extension uses a six-hour, stale-while-revalidate models.dev
 snapshot in VS Code `globalState` only to fill metadata omitted by the live directory.

--- a/package.json
+++ b/package.json
@@ -81,6 +81,12 @@
     "configuration": {
       "title": "Codex Bridge for Copilot Chat",
       "properties": {
+        "openaiCodex.codexVersion": {
+          "type": "string",
+          "default": "",
+          "pattern": "^(?:\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)?$",
+          "description": "Optional Codex client version for the live model catalog. Leave empty to use the extension's checked-in version."
+        },
         "openaiCodex.reasoningEffort": {
           "type": "string",
           "enum": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,6 +54,10 @@ export function activate(context: vscode.ExtensionContext): void {
         || event.affectsConfiguration("openaiCodex.catalogCacheMinutes")) {
         provider.fireDidChange();
       }
+      if (event.affectsConfiguration("openaiCodex.codexVersion")) {
+        provider.clearModelCache();
+        provider.fireDidChange();
+      }
       if (event.affectsConfiguration("openaiCodex.showUsageStatusBar")) updateUsageStatusVisibility(usageStatus);
     }),
   );

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -13,6 +13,19 @@ test("declares optional native profile configuration without a management-comman
   assert.equal((provider.configuration as { required?: string[] }).required, undefined);
 });
 
+test("declares an optional Codex client-version override", () => {
+  const manifest = JSON.parse(readFileSync("package.json", "utf8")) as {
+    contributes: { configuration: { properties: Record<string, Record<string, unknown>> } };
+  };
+  const setting = manifest.contributes.configuration.properties["openaiCodex.codexVersion"];
+  assert.deepEqual(setting, {
+    type: "string",
+    default: "",
+    pattern: "^(?:\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)?$",
+    description: "Optional Codex client version for the live model catalog. Leave empty to use the extension's checked-in version.",
+  });
+});
+
 test("qualifies model IDs by profile and reports invalid native profile values", () => {
   assert.equal(profileQualifiedModelId("Work", "gpt-5.2"), "work::gpt-5.2");
   assert.equal(profileQualifiedModelId("default", "gpt-5.2"), "gpt-5.2");

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -32,6 +32,7 @@ import {
   type CodexUsageSnapshot,
 } from "./usage/domain";
 import { CodexTransport } from "./transport/client";
+import { codexModelsClientVersion } from "./transport/protocol";
 import { CatalogCache } from "./models/catalog-cache";
 import { ModelsDevMetadata, type MetadataCache } from "./models/metadata";
 import { activeProfileFromState, profileFromConfiguration, profileQualifiedModelId } from "./provider-profile";
@@ -87,6 +88,7 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
       oauth,
       userAgent,
       () => configuration().get("requestTimeoutSeconds", 600),
+      () => codexModelsClientVersion(configuration().get<string>("codexVersion")),
       fetcher,
     );
     this.metadata = new ModelsDevMetadata(metadataCache, fetcher);

--- a/src/transport/client.ts
+++ b/src/transport/client.ts
@@ -10,7 +10,6 @@ import {
   CHATGPT_CODEX_RESET_CREDITS_URL,
   CHATGPT_CODEX_RESPONSES_URL,
   CHATGPT_CODEX_USAGE_URL,
-  CODEX_MODELS_CLIENT_VERSION,
   OAUTH_ORIGINATOR,
   chatgptCodexModelsUrl,
 } from "./protocol";
@@ -22,15 +21,17 @@ export class CodexTransport {
     private readonly oauth: OpenAIOAuth,
     private readonly userAgent: string,
     private readonly requestTimeoutSeconds: () => number,
+    private readonly codexModelsClientVersion: () => string,
     private readonly fetcher: typeof fetch = fetch,
   ) {}
 
   sendModels(cancellation: vscode.CancellationToken, profile = DEFAULT_OAUTH_PROFILE): Promise<Response> {
-    return this.withAuthRetry(profile, (credentials) => this.fetchWithCancellation(chatgptCodexModelsUrl(CODEX_MODELS_CLIENT_VERSION), {
+    const clientVersion = this.codexModelsClientVersion();
+    return this.withAuthRetry(profile, (credentials) => this.fetchWithCancellation(chatgptCodexModelsUrl(clientVersion), {
       headers: {
         ...this.authHeaders(credentials, "application/json"),
         Originator: OAUTH_ORIGINATOR,
-        Version: CODEX_MODELS_CLIENT_VERSION,
+        Version: clientVersion,
       },
     }, cancellation));
   }

--- a/src/transport/protocol.test.ts
+++ b/src/transport/protocol.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   CODEX_MODELS_CLIENT_VERSION,
+  codexModelsClientVersion,
   chatgptCodexModelsUrl,
   EXTENSION_DISPLAY_NAME,
   EXTENSION_PRODUCT_ID,
@@ -19,4 +20,11 @@ test("uses a consistent independent extension identity", () => {
 test("uses the checked-in Codex release version for backend requests", () => {
   assert.match(CODEX_MODELS_CLIENT_VERSION, /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
   assert.equal(chatgptCodexModelsUrl(CODEX_MODELS_CLIENT_VERSION), `https://chatgpt.com/backend-api/codex/models?client_version=${CODEX_MODELS_CLIENT_VERSION}`);
+});
+
+test("uses a valid configured Codex version and otherwise falls back to the checked-in version", () => {
+  assert.equal(codexModelsClientVersion("0.150.0"), "0.150.0");
+  assert.equal(codexModelsClientVersion(" 0.150.0-beta.1 "), "0.150.0-beta.1");
+  assert.equal(codexModelsClientVersion("latest"), CODEX_MODELS_CLIENT_VERSION);
+  assert.equal(codexModelsClientVersion(undefined), CODEX_MODELS_CLIENT_VERSION);
 });

--- a/src/transport/protocol.ts
+++ b/src/transport/protocol.ts
@@ -1,5 +1,7 @@
 /** Stable protocol identity and endpoint constants for this extension. */
 
+const CODEX_RELEASE_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
 export const EXTENSION_DISPLAY_NAME = "Codex Bridge for Copilot Chat";
 export const EXTENSION_PRODUCT_ID = "openai-oauth-copilot-chat";
 export const OAUTH_ORIGINATOR = EXTENSION_PRODUCT_ID;
@@ -12,6 +14,7 @@ export const OPENAI_REDIRECT_URI = "http://localhost:1455/auth/callback";
 /**
  * Codex client version sent to the live model directory.
  * Update this checked-in value manually with `npm run update-codex-version`.
+ * Users can temporarily override it with `openaiCodex.codexVersion`.
  *
  * @example
  * ```ts
@@ -20,7 +23,7 @@ export const OPENAI_REDIRECT_URI = "http://localhost:1455/auth/callback";
  *
  * @see {@link chatgptCodexModelsUrl}
  */
-export const CODEX_MODELS_CLIENT_VERSION = "0.146.0";
+export const CODEX_MODELS_CLIENT_VERSION = "0.149.0";
 export const CHATGPT_CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
 export const CHATGPT_CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 export const CHATGPT_CODEX_RESET_CREDITS_URL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
@@ -31,14 +34,20 @@ export const CHATGPT_CODEX_RESET_CREDIT_CONSUME_URL = `${CHATGPT_CODEX_RESET_CRE
  *
  * @example
  * ```ts
- * chatgptCodexModelsUrl("0.146.0");
- * // "https://chatgpt.com/backend-api/codex/models?client_version=0.146.0"
+ * chatgptCodexModelsUrl("0.149.0");
+ * // "https://chatgpt.com/backend-api/codex/models?client_version=0.149.0"
  * ```
  *
  * @see {@link CODEX_MODELS_CLIENT_VERSION}
  */
 export function chatgptCodexModelsUrl(clientVersion: string): string {
   return `https://chatgpt.com/backend-api/codex/models?client_version=${encodeURIComponent(clientVersion)}`;
+}
+
+/** Resolves an optional VS Code override for the live Codex model directory. */
+export function codexModelsClientVersion(configuredVersion: string | undefined): string {
+  const version = configuredVersion?.trim();
+  return version && CODEX_RELEASE_VERSION_PATTERN.test(version) ? version : CODEX_MODELS_CLIENT_VERSION;
 }
 
 /**


### PR DESCRIPTION
## Summary

- add an optional `openaiCodex.codexVersion` setting for the live model catalog
- keep the checked-in Codex version as the fallback and update it to `0.149.0`
- clear the catalog cache when the override changes

## Validation

- `npm run check`
- `npm run package`