### PR TITLE
fix: make account switching route explicit

### DIFF
--- a/.changeset/clear-profile-routing.md
+++ b/.changeset/clear-profile-routing.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": patch
+---
+
+Clarify that profile selection controls usage and management, and offer the VS Code chat model picker to switch the account used for inference.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       },
       {
         "command": "openaiCodex.selectProfile",
-        "title": "Codex Bridge: Select Active Profile"
+        "title": "Codex Bridge: Select Profile for Usage and Management"
       },
       {
         "command": "openaiCodex.signIn",

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -179,11 +179,15 @@ async function selectProfile(oauth: OpenAIOAuth, provider: OpenAICodexProvider):
       const session = await oauth.sessionInfo(profile);
       return { label: profile, description: session?.email ?? "Signed in", profile };
     })),
-    { title: "Select the active Codex Bridge profile" },
+    { title: "Select the Codex Bridge profile for usage and management" },
   );
   if (!picked) return;
   provider.setActiveProfile(picked.profile);
-  vscode.window.showInformationMessage(`Codex Bridge profile “${picked.profile}” is now active for usage and management commands.`);
+  const choose = await vscode.window.showInformationMessage(
+    `Codex Bridge profile “${picked.profile}” is now active for usage and management. Chat requests keep using the account attached to the selected model entry.`,
+    "Choose Chat Model",
+  );
+  if (choose === "Choose Chat Model") await vscode.commands.executeCommand("workbench.action.chat.openModelPicker");
 }
 
 async function promptProfileId(): Promise<string | undefined> {

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -5,12 +5,19 @@ import { activeProfileFromState, profileFromConfiguration, profileQualifiedModel
 
 test("declares optional native profile configuration without a management-command override", () => {
   const manifest = JSON.parse(readFileSync("package.json", "utf8")) as {
-    contributes: { languageModelChatProviders: Array<Record<string, unknown>> };
+    contributes: {
+      commands: Array<{ command: string; title: string }>;
+      languageModelChatProviders: Array<Record<string, unknown>>;
+    };
   };
   const provider = manifest.contributes.languageModelChatProviders.find((item) => item.vendor === "openai-codex");
   assert.ok(provider);
   assert.equal(provider.managementCommand, undefined);
   assert.equal((provider.configuration as { required?: string[] }).required, undefined);
+  assert.match(
+    manifest.contributes.commands.find((item) => item.command === "openaiCodex.selectProfile")?.title ?? "",
+    /Usage and Management/,
+  );
 });
 
 test("declares an optional Codex client-version override", () => {

--- a/src/transport/client.test.ts
+++ b/src/transport/client.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type * as vscode from "vscode";
+import { CodexTransport } from "./client";
+
+test("routes each response through the profile embedded in the selected model", async () => {
+  const requestedProfiles: string[] = [];
+  const oauth = {
+    async getAccessToken(_forceRefresh: boolean, profile: string) {
+      requestedProfiles.push(profile);
+      return { token: `${profile}-token`, accountId: `${profile}-account` };
+    },
+  };
+  const requests: Array<{ authorization: string | null; accountId: string | null }> = [];
+  const fetcher: typeof fetch = async (_input, init) => {
+    const headers = new Headers(init?.headers);
+    requests.push({
+      authorization: headers.get("Authorization"),
+      accountId: headers.get("ChatGPT-Account-ID"),
+    });
+    return new Response(null, { status: 200 });
+  };
+  const cancellation = {
+    isCancellationRequested: false,
+    onCancellationRequested: () => ({ dispose() {} }),
+  } as unknown as vscode.CancellationToken;
+  const transport = new CodexTransport(
+    oauth as never,
+    "test-agent",
+    () => 10,
+    () => "1.0.0",
+    fetcher,
+  );
+
+  await transport.sendResponse({ model: "gpt-test" }, cancellation, "personal");
+  await transport.sendResponse({ model: "gpt-test" }, cancellation, "work");
+
+  assert.deepEqual(requestedProfiles, ["personal", "work"]);
+  assert.deepEqual(requests, [
+    { authorization: "Bearer personal-token", accountId: "personal-account" },
+    { authorization: "Bearer work-token", accountId: "work-account" },
+  ]);
+});


### PR DESCRIPTION
## Summary
- rename the profile command to state its usage and management scope
- explain that inference remains attached to the selected VS Code model entry
- offer the native chat model picker immediately after profile selection
- add simulated multi-account transport coverage for bearer token and ChatGPT account ID routing

## Root cause
VS Code binds each model to its Language Models provider entry. The extension’s **Select Active Profile** command only changed the profile used by usage and management commands, but its name implied that inference would switch too. Requests correctly followed the profile embedded in the selected model, so a chat that retained the old model entry retained the old account and its quota state.

## Verification
- `npm run check` (76 tests)
- `npm run package`
- Extension Development Host: command title and activation verified

Fixes #32