### PR TITLE
chore: refresh Codex model catalog client

### DIFF
--- a/.changeset/fresh-codex-models.md
+++ b/.changeset/fresh-codex-models.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": patch
+---
+
+Refresh the live Codex model catalog with the latest client version.

--- a/src/transport/protocol.ts
+++ b/src/transport/protocol.ts
@@ -23,7 +23,7 @@ export const OPENAI_REDIRECT_URI = "http://localhost:1455/auth/callback";
  *
  * @see {@link chatgptCodexModelsUrl}
  */
-export const CODEX_MODELS_CLIENT_VERSION = "0.149.0";
+export const CODEX_MODELS_CLIENT_VERSION = "0.151.0";
 export const CHATGPT_CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
 export const CHATGPT_CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 export const CHATGPT_CODEX_RESET_CREDITS_URL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";


### PR DESCRIPTION
## Summary
- update the live Codex model-directory client version from 0.149.0 to 0.151.0
- add a patch Changeset for the catalog refresh

## Research
- OpenAI's current Codex release is 0.151.0
- the provider continues to discover visible models dynamically and enrich missing public metadata through models.dev

## Verification
- npm run check (76 tests)
- npm run package