### PR TITLE
Harden Responses stream recovery and transient retries

### DIFF
--- a/.changeset/calm-response-recovery.md
+++ b/.changeset/calm-response-recovery.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": patch
+---
+
+Recover final Responses API text when deltas are missing and retry transient inference connection failures before a response is received.

--- a/src/transport/client.test.ts
+++ b/src/transport/client.test.ts
@@ -41,3 +41,25 @@ test("routes each response through the profile embedded in the selected model", 
     { authorization: "Bearer work-token", accountId: "work-account" },
   ]);
 });
+
+test("retries transient response fetch failures without refreshing OAuth", async () => {
+  let tokenRequests = 0;
+  let fetchAttempts = 0;
+  const oauth = { async getAccessToken() { tokenRequests += 1; return { token: "token" }; } };
+  const fetcher: typeof fetch = async () => {
+    fetchAttempts += 1;
+    if (fetchAttempts < 3) throw new TypeError("fetch failed", { cause: new Error("ECONNRESET") });
+    return new Response(null, { status: 200 });
+  };
+  const cancellation = {
+    isCancellationRequested: false,
+    onCancellationRequested: () => ({ dispose() {} }),
+  } as unknown as vscode.CancellationToken;
+  const transport = new CodexTransport(oauth as never, "test-agent", () => 10, () => "1.0.0", fetcher);
+
+  const response = await transport.sendResponse({ model: "gpt-test" }, cancellation);
+
+  assert.equal(response.status, 200);
+  assert.equal(fetchAttempts, 3);
+  assert.equal(tokenRequests, 1);
+});

--- a/src/transport/client.ts
+++ b/src/transport/client.ts
@@ -80,7 +80,7 @@ export class CodexTransport {
           ...transportHeaders,
         },
         body: JSON.stringify(body),
-      }, cancellation);
+      }, cancellation, true);
     });
   }
 
@@ -106,16 +106,41 @@ export class CodexTransport {
     url: string,
     init: RequestInit,
     cancellation: vscode.CancellationToken,
+    retryTransient = false,
   ): Promise<Response> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), Math.max(10, this.requestTimeoutSeconds()) * 1000);
     const listener = cancellation.onCancellationRequested(() => controller.abort());
     if (cancellation.isCancellationRequested) controller.abort();
     try {
-      return await this.fetcher(url, { ...init, signal: controller.signal });
+      for (let attempt = 0; ; attempt += 1) {
+        try {
+          return await this.fetcher(url, { ...init, signal: controller.signal });
+        } catch (error) {
+          if (!retryTransient || attempt >= 2 || controller.signal.aborted || !isTransientNetworkError(error)) throw error;
+          await waitForRetry(250 * 2 ** attempt, controller.signal);
+        }
+      }
     } finally {
       clearTimeout(timeout);
       listener.dispose();
     }
   }
+}
+
+function isTransientNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error) || error.name === "AbortError") return false;
+  const cause = (error as Error & { cause?: unknown }).cause;
+  const detail = `${error.name}: ${error.message} ${cause instanceof Error ? `${cause.name}: ${cause.message}` : ""}`;
+  return /fetch failed|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ENETUNREACH|EHOSTUNREACH|UND_ERR_CONNECT_TIMEOUT|UND_ERR_SOCKET|socket hang up/i.test(detail);
+}
+
+function waitForRetry(delay: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, delay);
+    signal.addEventListener("abort", () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    }, { once: true });
+  });
 }

--- a/src/transport/responses.test.ts
+++ b/src/transport/responses.test.ts
@@ -79,3 +79,18 @@ test("extracts Responses API inference usage from the completed event", () => {
   const events = parser.push('data: {"type":"response.completed","response":{"usage":{"input_tokens":120,"output_tokens":30,"total_tokens":150}}}\n\n');
   assert.deepEqual(events, [{ usage: { input_tokens: 120, output_tokens: 30, total_tokens: 150 } }]);
 });
+
+test("recovers completed response text when no text delta was delivered", () => {
+  const parser = new ResponsesStreamParser();
+  const events = parser.push('data: {"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"recovered"}]}]}}\n\n');
+  assert.deepEqual(events, [{ text: "recovered" }]);
+});
+
+test("does not repeat completed response text after streaming deltas", () => {
+  const parser = new ResponsesStreamParser();
+  const events = parser.push([
+    'data: {"type":"response.output_text.delta","delta":"answer"}',
+    'data: {"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"answer"}]}]}}',
+  ].join("\n\n") + "\n\n");
+  assert.deepEqual(events, [{ text: "answer" }]);
+});

--- a/src/transport/responses.ts
+++ b/src/transport/responses.ts
@@ -26,6 +26,7 @@ export class ResponsesStreamParser {
   private buffer = "";
   private readonly toolArguments = new Map<string, string>();
   private readonly imageGenerationCalls = new Set<string>();
+  private textDeltaSeen = false;
 
   /**
    * Adds a transport chunk and returns every complete event it contains.
@@ -66,7 +67,10 @@ export class ResponsesStreamParser {
     }
     const type = typeof value.type === "string" ? value.type : "";
     const delta = typeof value.delta === "string" ? value.delta : "";
-    if (type === "response.output_text.delta" && delta) return [{ text: delta }];
+    if (type === "response.output_text.delta" && delta) {
+      this.textDeltaSeen = true;
+      return [{ text: delta }];
+    }
     if ((type === "response.reasoning_summary_text.delta" || type === "response.reasoning_text.delta") && delta) {
       return [{ reasoning: delta }];
     }
@@ -112,8 +116,13 @@ export class ResponsesStreamParser {
       if (Array.isArray(output)) {
         for (const item of output) {
           if (item && typeof item === "object" && !Array.isArray(item)) {
-            const imageEvent = imageGenerationEvent(item as Record<string, unknown>, this.imageGenerationCalls);
+            const outputItem = item as Record<string, unknown>;
+            const imageEvent = imageGenerationEvent(outputItem, this.imageGenerationCalls);
             if (imageEvent) events.push(imageEvent);
+            if (!this.textDeltaSeen) {
+              const text = responseOutputText(outputItem);
+              if (text) events.push({ text });
+            }
           }
         }
       }
@@ -127,6 +136,16 @@ export class ResponsesStreamParser {
     }
     return undefined;
   }
+}
+
+function responseOutputText(item: Record<string, unknown>): string | undefined {
+  if (item.type !== "message" || !Array.isArray(item.content)) return undefined;
+  const text = item.content.flatMap((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+    const part = value as Record<string, unknown>;
+    return (part.type === "output_text" || part.type === "text") && typeof part.text === "string" ? [part.text] : [];
+  }).join("");
+  return text || undefined;
 }
 
 function recordField(value: Record<string, unknown>, key: string): Record<string, unknown> | undefined {


### PR DESCRIPTION
## Summary
- recover final Responses API text when deltas are absent without duplicating streamed text
- retry transient inference connection failures twice with bounded backoff
- add regression coverage and a patch Changeset

## Verification
- `npm run check`
- `npm run package`
- verified in the `copilot-chat (Workspace)` window with GPT 5.6 Luna reading the implementation and Changeset via workspace tools
