### PR TITLE
Register OpenAI model pricing metadata

### DIFF
--- a/.changeset/calm-model-prices.md
+++ b/.changeset/calm-model-prices.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": patch
+---
+
+Register model-specific OpenAI token pricing and relative cost tiers with VS Code.

--- a/src/models/catalog.ts
+++ b/src/models/catalog.ts
@@ -1,6 +1,7 @@
 /** Model-directory types and normalization for the live Codex picker. */
 
 import type { ModelsDevModelMetadata } from "./metadata";
+import type { ModelCost } from "./pricing";
 
 /** Processing speed requested for a model. */
 export type SpeedMode = "normal" | "fast";
@@ -37,6 +38,7 @@ export interface CodexModelMetadata {
   priority: number;
   releaseDate?: string;
   lastUpdated?: string;
+  cost?: ModelCost;
 }
 
 /** A picker-ready model entry, including its selected speed mode. */
@@ -158,6 +160,7 @@ export function enrichCodexModel(model: CodexModelMetadata, metadata: ModelsDevM
     output,
     releaseDate: metadata.releaseDate,
     lastUpdated: metadata.lastUpdated,
+    cost: metadata.cost,
   };
 }
 

--- a/src/models/metadata.test.ts
+++ b/src/models/metadata.test.ts
@@ -24,6 +24,7 @@ const payload = { openai: { models: { "gpt-test": {
   tool_call: true,
   modalities: { input: ["text", "image"] },
   limit: { context: 200_000, input: 175_000, output: 20_000 },
+  cost: { input: 4, cache_read: 0.4, output: 20 },
 } } } };
 
 test("normalizes the OpenAI models.dev provider", () => {
@@ -32,8 +33,10 @@ test("normalizes the OpenAI models.dev provider", () => {
   assert.equal(snapshot.models["gpt-test"]?.maxInputTokens, 175_000);
   assert.equal(snapshot.models["gpt-test"]?.imageInput, true);
   assert.deepEqual(snapshot.models["gpt-test"]?.reasoningOptions, ["low", "high"]);
+  assert.deepEqual(snapshot.models["gpt-test"]?.cost, { input: 4, cacheRead: 0.4, output: 20 });
   assert.equal(parseCachedModelsDevSnapshot(snapshot)?.models["gpt-test"]?.toolCalling, true);
   assert.equal(parseCachedModelsDevSnapshot(snapshot)?.models["gpt-test"]?.maxInputTokens, 175_000);
+  assert.deepEqual(parseCachedModelsDevSnapshot(snapshot)?.models["gpt-test"]?.cost, { input: 4, cacheRead: 0.4, output: 20 });
   assert.equal(parseCachedModelsDevSnapshot({ fetchedAt: -1, models: {} }), undefined);
 });
 

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -1,3 +1,5 @@
+import type { ModelCost } from "./pricing";
+
 export const MODELS_DEV_API_URL = "https://models.dev/api.json";
 export const MODELS_DEV_CACHE_KEY = "openaiCodex.modelsDevMetadata.v1";
 export const MODELS_DEV_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
@@ -17,6 +19,7 @@ export interface ModelsDevModelMetadata {
   readonly reasoningOptions?: readonly string[];
   readonly releaseDate?: string;
   readonly lastUpdated?: string;
+  readonly cost?: ModelCost;
 }
 
 export interface ModelsDevSnapshot {
@@ -114,6 +117,7 @@ function normalizeModel(key: string, value: unknown): ModelsDevModelMetadata | u
   if (!id) return undefined;
   const modalities = asRecord(raw.modalities);
   const limit = asRecord(raw.limit);
+  const cost = normalizeCost(asRecord(raw.cost));
   return {
     id,
     name: optionalString(raw.name),
@@ -128,6 +132,7 @@ function normalizeModel(key: string, value: unknown): ModelsDevModelMetadata | u
     reasoningOptions: normalizeReasoningOptions(raw.reasoning_options),
     releaseDate: optionalString(raw.release_date),
     lastUpdated: optionalString(raw.last_updated),
+    ...(cost ? { cost } : {}),
   };
 }
 
@@ -138,6 +143,7 @@ function parseCachedModel(key: string, value: unknown): ModelsDevModelMetadata |
   if (!id || !validOptionalNumber(raw.contextLength) || !validOptionalNumber(raw.maxInputTokens) || !validOptionalNumber(raw.maxOutputTokens)) return undefined;
   if (!validOptionalBoolean(raw.imageInput) || !validOptionalBoolean(raw.toolCalling) || !validOptionalBoolean(raw.reasoning)) return undefined;
   if (raw.reasoningOptions !== undefined && !isStringArray(raw.reasoningOptions)) return undefined;
+  const cost = parseCost(raw.cost);
   return {
     id,
     name: optionalString(raw.name),
@@ -152,7 +158,26 @@ function parseCachedModel(key: string, value: unknown): ModelsDevModelMetadata |
     reasoningOptions: raw.reasoningOptions === undefined ? undefined : stringArray(raw.reasoningOptions),
     releaseDate: optionalString(raw.releaseDate),
     lastUpdated: optionalString(raw.lastUpdated),
+    ...(cost ? { cost } : {}),
   };
+}
+
+function normalizeCost(raw: Record<string, unknown> | undefined): ModelCost | undefined {
+  const input = optionalNonNegativeNumber(raw?.input);
+  const output = optionalNonNegativeNumber(raw?.output);
+  if (input === undefined || output === undefined) return undefined;
+  const cacheRead = optionalNonNegativeNumber(raw?.cache_read);
+  return { input, output, ...(cacheRead === undefined ? {} : { cacheRead }) };
+}
+
+function parseCost(value: unknown): ModelCost | undefined {
+  const raw = asRecord(value);
+  if (!raw) return undefined;
+  const input = optionalNonNegativeNumber(raw.input);
+  const output = optionalNonNegativeNumber(raw.output);
+  const cacheRead = optionalNonNegativeNumber(raw.cacheRead);
+  if (input === undefined || output === undefined) return undefined;
+  return { input, output, ...(cacheRead === undefined ? {} : { cacheRead }) };
 }
 
 function normalizeReasoningOptions(value: unknown): string[] | undefined {
@@ -177,6 +202,7 @@ function stringValue(value: unknown): string | undefined { return typeof value =
 function optionalString(value: unknown): string | undefined { return value === undefined ? undefined : stringValue(value); }
 function optionalBoolean(value: unknown): boolean | undefined { return typeof value === "boolean" ? value : undefined; }
 function optionalTokenCount(value: unknown): number | undefined { return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined; }
+function optionalNonNegativeNumber(value: unknown): number | undefined { return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined; }
 function stringArray(value: unknown): string[] { return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []; }
 function isStringArray(value: unknown): value is string[] { return Array.isArray(value) && value.every((item) => typeof item === "string"); }
 function validTimestamp(value: unknown): value is number { return typeof value === "number" && Number.isFinite(value) && value >= 0; }

--- a/src/models/pricing.test.ts
+++ b/src/models/pricing.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { costCategory, modelPricingFields, openAIModelCost } from "./pricing";
+
+test("converts USD per-million rates to VS Code pricing fields", () => {
+  assert.deepEqual(modelPricingFields({ input: 2, cacheRead: 0.2, output: 12 }), {
+    pricing: "In: $2 · Out: $12 /1M tokens",
+    inputCost: 200,
+    outputCost: 1200,
+    cacheCost: 20,
+    priceCategory: "medium",
+  });
+  assert.deepEqual(modelPricingFields({ input: 0, cacheRead: 0, output: 0 }), {
+    pricing: "Free",
+    inputCost: 0,
+    outputCost: 0,
+    cacheCost: 0,
+    priceCategory: "low",
+  });
+  assert.equal(modelPricingFields(undefined), undefined);
+});
+
+test("uses official standard rates when models.dev metadata is unavailable", () => {
+  assert.deepEqual(openAIModelCost("gpt-5.6-terra"), { input: 2, cacheRead: 0.2, output: 12 });
+  assert.equal(openAIModelCost("future-model"), undefined);
+});
+
+test("categorizes a weighted three-to-one input and output blend", () => {
+  assert.equal(costCategory({ input: 0.2, output: 1.2 }), "low");
+  assert.equal(costCategory({ input: 2, output: 12 }), "medium");
+  assert.equal(costCategory({ input: 5, output: 25 }), "high");
+  assert.equal(costCategory({ input: 30, output: 180 }), "very_high");
+});

--- a/src/models/pricing.ts
+++ b/src/models/pricing.ts
@@ -1,0 +1,64 @@
+export interface ModelCost {
+  readonly input: number;
+  readonly output: number;
+  readonly cacheRead?: number;
+}
+
+export interface ModelPricingFields {
+  readonly pricing: string;
+  readonly inputCost: number;
+  readonly outputCost: number;
+  readonly cacheCost?: number;
+  readonly priceCategory: "low" | "medium" | "high" | "very_high";
+}
+
+const OFFICIAL_MODEL_COSTS: Readonly<Record<string, ModelCost>> = {
+  "gpt-5.6-sol": { input: 4, cacheRead: 0.4, output: 20 },
+  "gpt-5.6": { input: 4, cacheRead: 0.4, output: 20 },
+  "gpt-5.6-terra": { input: 2, cacheRead: 0.2, output: 12 },
+  "gpt-5.6-luna": { input: 0.2, cacheRead: 0.02, output: 1.2 },
+  "gpt-5.5": { input: 5, cacheRead: 0.5, output: 30 },
+  "gpt-5.5-pro": { input: 30, output: 180 },
+  "gpt-5.4": { input: 2.5, cacheRead: 0.25, output: 15 },
+  "gpt-5.4-mini": { input: 0.75, cacheRead: 0.075, output: 4.5 },
+  "gpt-5.4-pro": { input: 30, output: 180 },
+  "gpt-5.3-codex": { input: 1.75, cacheRead: 0.175, output: 14 },
+  "gpt-5.3-codex-spark": { input: 1.75, cacheRead: 0.175, output: 14 },
+  "gpt-5.2": { input: 1.75, cacheRead: 0.175, output: 14 },
+};
+
+export function openAIModelCost(id: string, discovered?: ModelCost): ModelCost | undefined {
+  return discovered ?? OFFICIAL_MODEL_COSTS[id];
+}
+
+export function modelPricingFields(cost: ModelCost | undefined): ModelPricingFields | undefined {
+  if (!cost) return undefined;
+  if (cost.input === 0 && cost.output === 0) {
+    return {
+      pricing: "Free",
+      inputCost: 0,
+      outputCost: 0,
+      ...(cost.cacheRead === undefined ? {} : { cacheCost: 0 }),
+      priceCategory: "low",
+    };
+  }
+  return {
+    pricing: `In: $${formatPrice(cost.input)} · Out: $${formatPrice(cost.output)} /1M tokens`,
+    inputCost: Math.round(cost.input * 100),
+    outputCost: Math.round(cost.output * 100),
+    ...(cost.cacheRead === undefined ? {} : { cacheCost: Math.round(cost.cacheRead * 100) }),
+    priceCategory: costCategory(cost),
+  };
+}
+
+export function costCategory(cost: Pick<ModelCost, "input" | "output">): ModelPricingFields["priceCategory"] {
+  const weighted = cost.input * 3 + cost.output;
+  if (weighted <= 2) return "low";
+  if (weighted <= 25) return "medium";
+  if (weighted <= 50) return "high";
+  return "very_high";
+}
+
+function formatPrice(value: number): string {
+  return value.toFixed(6).replace(/\.?0+$/, "");
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -35,6 +35,7 @@ import { CodexTransport } from "./transport/client";
 import { codexModelsClientVersion } from "./transport/protocol";
 import { CatalogCache } from "./models/catalog-cache";
 import { ModelsDevMetadata, type MetadataCache } from "./models/metadata";
+import { modelPricingFields, openAIModelCost } from "./models/pricing";
 import { activeProfileFromState, profileFromConfiguration, profileQualifiedModelId } from "./provider-profile";
 
 /** Live model information registered with VS Code Chat. */
@@ -227,6 +228,7 @@ export class OpenAICodexProvider implements vscode.LanguageModelChatProvider<Cod
         maxInputTokens: model.input,
         maxOutputTokens: model.output,
         isUserSelectable: true,
+        ...(modelPricingFields(openAIModelCost(model.rawModelId, model.cost)) ?? {}),
         isBYOK: true,
         requiresAuthorization: { label: `Codex Bridge (${profile})` },
         configurationSchema: buildModelConfigurationSchema(optionSpec, defaults),

--- a/src/vscode/proposed-chat-provider.d.ts
+++ b/src/vscode/proposed-chat-provider.d.ts
@@ -7,6 +7,10 @@ declare module "vscode" {
   export interface LanguageModelChatInformation {
     readonly requiresAuthorization?: true | { label: string };
     readonly pricing?: string;
+    readonly inputCost?: number;
+    readonly outputCost?: number;
+    readonly cacheCost?: number;
+    readonly priceCategory?: string;
     readonly isUserSelectable?: boolean;
     readonly configurationSchema?: LanguageModelConfigurationSchema;
     readonly targetChatSessionType?: string;


### PR DESCRIPTION
## Summary

- Register OpenAI input, cached-input, and output pricing with VS Code.
- Enrich live Codex models with pricing from models.dev.
- Use official standard-rate fallbacks for bundled models when live pricing is unavailable.
- Expose AI-credit costs, display labels, and relative price categories.
- Add pricing tests and a patch Changeset.

## Pricing sources

- https://developers.openai.com/api/docs/pricing
- https://models.dev/

## Verification

- `npm run check` — 82 tests passed
- `npm run package` — packaged version 0.10.5