### PR TITLE
Restore Fast picker options with context controls

### DIFF
--- a/.changeset/restore-fast-picker.md
+++ b/.changeset/restore-fast-picker.md
@@ -1,0 +1,5 @@
+---
+"openai-oauth-copilot-chat": patch
+---
+
+Restore picker access to Fast mode on models with selectable context windows by pairing each reasoning effort with a Fast choice.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This native VS Code `LanguageModelChatProvider` handles OpenAI OAuth locally and
 3. Open **Chat: Manage Language Models**, select **Add Models → Codex Bridge**, name the entry, and enter the same profile ID.
 4. Repeat those steps with another profile ID to keep work and personal ChatGPT accounts available side by side.
 
-The authenticated Codex catalog remains authoritative. Composer controls override workspace defaults; reasoning defaults to High when supported, while hosted Web Search and Image Generation remain off until enabled. Click the Codex status-bar item to inspect five-hour and weekly quota, reset timing, and tokens observed by this extension.
+The authenticated Codex catalog remains authoritative. Composer controls override workspace defaults; reasoning defaults to Low when supported, while hosted Web Search and Image Generation remain off until enabled. Click the Codex status-bar item to inspect five-hour and weekly quota, reset timing, and tokens observed by this extension.
 
 ## Documentation
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -14,8 +14,7 @@ name, description, context window, image-input and tool-calling capabilities,
 and the reasoning levels (including defaults) offered by the Codex backend.
 Hidden directory entries and models without a usable reasoning level are
 omitted from the picker. Fast remains a capability on the normal entry and is
-selected through the model's native Speed Mode configuration instead of a
-second picker entry.
+selected through the model's configuration instead of a second picker entry.
 
 ## models.dev enrichment
 
@@ -72,4 +71,7 @@ to replace a saved zero selection.
 
 Context Window uses the dedicated tokens group so it remains visible beside
 reasoning controls. VS Code renders only one enum property per group.
-Speed Mode remains available by right-clicking the model in **Chat: Manage Language Models**.
+For Fast-capable models, the reasoning control therefore pairs each effort with
+a Fast choice, such as High and High Fast. Selecting a Fast choice sends the
+same priority service tier as the standalone Speed Mode control used by models
+without a Context Window selector.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -9,10 +9,11 @@ Use **Codex Bridge: Add ChatGPT Account** to authenticate and assign the account
 The `default` profile preserves an existing single-account session, but after upgrading you must add a Codex Bridge entry in **Chat: Manage Language Models** and use `default` as its profile ID. **Codex Bridge: Select Active Profile** chooses which account the status bar and management commands display; model requests always use the account attached to the selected Language Models entry.
 
 Each model exposes the reasoning efforts advertised by the live Codex catalog. Ordered
-effort controls default to High when the model supports it; otherwise the catalog default
-is retained. Models
-that advertise the `fast` additional speed tier expose a native **Speed Mode** control
-with Normal and Fast choices. Selecting Fast requests faster processing with increased
+effort controls default to Low when the model supports it; otherwise the catalog default
+is retained. Models that advertise the `fast` additional speed tier expose Fast choices
+in their model configuration. When Context Window is available, each effort is paired
+with a Fast choice such as High and High Fast; otherwise a separate **Speed Mode** control
+provides Normal and Fast choices. Selecting Fast requests faster processing with increased
 account usage without adding a separate Fast model entry. The selected **profile for usage and management** is restored after restart; it never changes the account attached to a model entry.
 
 The `openaiCodex.reasoningSummary` setting controls the Responses API

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
             "max",
             "ultra"
           ],
-          "default": "high",
+          "default": "low",
           "deprecationMessage": "Legacy workspace fallback retained for compatibility; prefer the live model picker.",
           "description": "Legacy default reasoning effort sent to Codex when no model-specific value is selected. Unsupported values fall back to the live model default."
         },

--- a/src/models/options.test.ts
+++ b/src/models/options.test.ts
@@ -168,7 +168,7 @@ test("carries the live Fast-tier description into the picker schema", () => {
   ]);
 });
 
-test("defaults ordered reasoning controls to high when the model supports it", () => {
+test("defaults ordered reasoning controls to low when the model supports it", () => {
   const optionSpec = modelOptionSpec({
     reasoningLevels: [
       { effort: "low", description: "Lighter reasoning" },
@@ -180,8 +180,8 @@ test("defaults ordered reasoning controls to high when the model supports it", (
     defaultReasoningSummary: "none",
   });
 
-  assert.equal(optionSpec.defaultEffort, "high");
-  assert.equal(buildModelConfigurationSchema(optionSpec).properties.reasoningEffort.default, "high");
+  assert.equal(optionSpec.defaultEffort, "low");
+  assert.equal(buildModelConfigurationSchema(optionSpec).properties.reasoningEffort.default, "low");
 });
 
 test("omits reasoning summaries when disabled or unsupported", () => {
@@ -242,6 +242,42 @@ test("exposes the Context Window control when tiers fit", () => {
 
   const plain = buildModelConfigurationSchema(spec);
   assert.equal("contextSize" in plain.properties, false);
+});
+
+test("combines reasoning effort and Fast mode when Context Window uses the token control", () => {
+  const highSpec: ModelOptionSpec = {
+    ...spec,
+    efforts: ["high"],
+    descriptions: { high: "Deeper reasoning" },
+    defaultEffort: "high",
+  };
+  const schema = buildModelConfigurationSchema(
+    highSpec,
+    { speedMode: "fast", reasoningEffort: "high", reasoningSummary: "auto", webSearch: false, imageGeneration: false, contextSize: 0 },
+    contextSizeOptions(244_800),
+  );
+
+  assert.deepEqual(schema.properties.mode.enum, ["normal:high", "fast:high"]);
+  assert.deepEqual(schema.properties.mode.enumItemLabels, ["High", "High Fast"]);
+  assert.equal(schema.properties.mode.default, "fast:high");
+  assert.equal(schema.properties.mode.group, "navigation");
+  assert.equal("reasoningEffort" in schema.properties, false);
+  assert.equal("speedMode" in schema.properties, false);
+
+  const options = resolveModelRequestOptions(
+    highSpec,
+    { mode: "fast:high", reasoningEffort: "medium", speedMode: "normal" },
+    {},
+    "normal",
+  );
+  assert.deepEqual(applyModelRequestOptions({}, options), {
+    reasoning: { effort: "high", summary: "auto" },
+    service_tier: "priority",
+  });
+  assert.equal(
+    resolveModelRequestOptions(highSpec, { mode: "normal:high" }, { speedMode: "fast" }, "normal").speedMode,
+    "normal",
+  );
 });
 
 // Mirrors VS Code's context indicator contract: numeric selections replace input,

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -54,7 +54,7 @@ export function modelOptionSpec(
   return {
     efforts,
     descriptions: Object.fromEntries(model.reasoningLevels.map((level) => [level.effort, level.description])),
-    defaultEffort: efforts.includes("high") ? "high" : model.defaultReasoningEffort,
+    defaultEffort: efforts.includes("low") ? "low" : model.defaultReasoningEffort,
     supportsFast: model.supportsFast,
     fastDescription: model.fastDescription,
     supportsReasoningSummaryParameter: model.supportsReasoningSummaryParameter,
@@ -154,10 +154,10 @@ export function resolveModelRequestOptions(
   workspaceDefaults: Readonly<Record<string, unknown>>,
   speedMode: SpeedMode,
 ): ModelRequestOptions {
-  const legacyMode = parseLegacyMode(stringOption(requestConfiguration, "mode"));
-  // Prefer request-specific values, then legacy picker values, workspace fallbacks, and live model defaults.
-  const requestedEffort = parseConfiguredEffort(stringOption(requestConfiguration, "reasoningEffort"))
-    ?? legacyMode?.reasoningEffort
+  const selectedMode = parseLegacyMode(stringOption(requestConfiguration, "mode"));
+  // Prefer the combined picker value, then separate request settings, workspace fallbacks, and live model defaults.
+  const requestedEffort = selectedMode?.reasoningEffort
+    ?? parseConfiguredEffort(stringOption(requestConfiguration, "reasoningEffort"))
     ?? parseConfiguredEffort(stringOption(workspaceDefaults, "reasoningEffort"));
   const requestedSummary = parseConfiguredSummary(stringOption(requestConfiguration, "reasoningSummary"))
     ?? parseConfiguredSummary(stringOption(workspaceDefaults, "reasoningSummary"));
@@ -165,8 +165,8 @@ export function resolveModelRequestOptions(
     ?? booleanOption(workspaceDefaults, "webSearch");
   const requestedImageGeneration = booleanOption(requestConfiguration, "imageGeneration")
     ?? booleanOption(workspaceDefaults, "imageGeneration");
-  const requestedSpeed = parseConfiguredSpeed(stringOption(requestConfiguration, "speedMode"))
-    ?? legacyMode?.speedMode
+  const requestedSpeed = selectedMode?.speedMode
+    ?? parseConfiguredSpeed(stringOption(requestConfiguration, "speedMode"))
     ?? parseConfiguredSpeed(stringOption(workspaceDefaults, "speedMode"));
   const requestedContextSize = parseConfiguredContextSize(numberOption(requestConfiguration, "contextSize"));
   // A registered Fast variant is authoritative; settings cannot turn it back into a normal request.
@@ -213,24 +213,47 @@ export function buildModelConfigurationSchema(
     ? defaults.reasoningEffort
     : spec.defaultEffort;
   const defaultSummary = defaults?.reasoningSummary ?? spec.defaultReasoningSummary;
-  // Every Fast-capable model has one picker entry, so its Speed Mode toggle is
-  // available; legacy Fast defaults only choose the initial toggle value.
-  // VS Code renders one control per group; Context Window owns the tokens slot.
-  // Speed remains configurable through Manage Language Models.
-  const exposesSpeedMode = spec.supportsFast;
   const defaultSpeedMode = defaults?.speedMode === "fast" ? "fast" : "normal";
+  // VS Code renders one control per group. When Context Window occupies the
+  // tokens slot, fold Fast into the reasoning choices in the navigation slot.
+  const combinesSpeedMode = spec.supportsFast && Boolean(contextOptions?.length);
+  const exposesSpeedMode = spec.supportsFast && !combinesSpeedMode;
+  const modeOptions = spec.efforts.flatMap((effort) => {
+    const label = formatOptionLabel(effort);
+    const description = spec.descriptions[effort] ?? label;
+    return [
+      { value: `normal:${effort}`, label, description },
+      {
+        value: `fast:${effort}`,
+        label: `${label} Fast`,
+        description: `${description}. ${spec.fastDescription ?? "Faster generation with increased usage"}`,
+      },
+    ];
+  });
   return {
     type: "object",
     properties: {
-      reasoningEffort: {
-        type: "string",
-        title: "Reasoning Effort",
-        enum: [...spec.efforts],
-        enumItemLabels: spec.efforts.map(formatOptionLabel),
-        enumDescriptions: spec.efforts.map((effort) => spec.descriptions[effort] ?? formatOptionLabel(effort)),
-        default: defaultEffort,
-        group: "navigation",
-      },
+      ...(combinesSpeedMode ? {
+        mode: {
+          type: "string",
+          title: "Reasoning & Speed",
+          enum: modeOptions.map((option) => option.value),
+          enumItemLabels: modeOptions.map((option) => option.label),
+          enumDescriptions: modeOptions.map((option) => option.description),
+          default: `${defaultSpeedMode}:${defaultEffort}`,
+          group: "navigation",
+        },
+      } : {
+        reasoningEffort: {
+          type: "string",
+          title: "Reasoning Effort",
+          enum: [...spec.efforts],
+          enumItemLabels: spec.efforts.map(formatOptionLabel),
+          enumDescriptions: spec.efforts.map((effort) => spec.descriptions[effort] ?? formatOptionLabel(effort)),
+          default: defaultEffort,
+          group: "navigation",
+        },
+      }),
       webSearch: {
         type: "boolean",
         title: "Web Search",


### PR DESCRIPTION
## Summary

- pair each advertised reasoning effort with a Fast option when Context Window occupies VS Code's token-control slot
- keep the existing standalone Speed Mode control for models without selectable context tiers
- default reasoning to Low when the model advertises it, while preserving explicit user configuration
- document the picker behavior and include a patch changeset for the later release workflow

## Validation

- `npm run check` (102 tests)
- `npm run package`
- sideloaded `openai-oauth-copilot-chat-0.11.0.vsix` successfully