### PR TITLE
chore: sync documentation conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ out/
 .DS_Store
 *.log
 coverage/
+.vscode-test/
 .env
 .env.*
 !.env.example
+tmp/
+assets/Codex*

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,6 +4,9 @@
 .codex/**
 docs/**
 assets/cover.jpg
+assets/Codex*/**
+assets/*.zip
+tmp/**
 .env*
 .gitignore
 CODE_OF_CONDUCT.md

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,4 +1,24 @@
-# Development and releases
+# Development
+
+## Prerequisites
+
+- Node.js 22 or newer
+- npm
+- VS Code 1.131 or newer
+
+## Validate
+
+```bash
+npm ci
+npm test
+npm run package
+npx vsce ls
+```
+
+The tests compile strict TypeScript and use Node's built-in test runner. Network
+paths use injected fetch fakes; the normal test suite never calls OpenAI or
+ChatGPT with real credentials. `npm run package` validates the project and
+creates an installable VSIX.
 
 ## Architecture
 
@@ -30,36 +50,30 @@ The ChatGPT Codex endpoint requires a bearer token plus the ChatGPT account ID e
 
 Shared protocol constants live in [`src/transport/protocol.ts`](../src/transport/protocol.ts). OAuth and inference requests must use the extension originator and user agent defined there; do not identify requests as the official Codex CLI or OpenAI VS Code extension. The OAuth client and ChatGPT backend are undocumented integration surfaces and may change without notice.
 
-## Local workflow
+## Extension Development Host
 
-```sh
-npm run compile
-npm test
-npm run watch
-npm run package
-```
+1. Open this repository in VS Code.
+2. Press F5 and choose **Run Extension**.
+3. In the new window, sign in with **Codex Bridge: Sign in** (browser PKCE).
+4. Open Copilot Chat and confirm the Codex model group appears.
+5. Send a short prompt to confirm text streaming and usage reporting.
+6. Use agent mode to verify a model emits and completes a tool call.
+7. Inspect diagnostics and logs for accidental sensitive output.
 
-The checked-in Codex client version is updated manually from the official Codex
-releases API. When a new release is needed, run `npm run update-codex-version`,
-review the source diff, and then run the normal checks. Compilation and watch mode
-do not contact GitHub.
+## Release
 
-For local debugging, open this folder in VS Code and run **Run Codex Bridge Extension** from the Run and Debug view (or press F5) to launch an Extension Development Host. Authentication and live connection testing must be performed in that host.
-
-Install a local build with:
-
-```bash
-code --install-extension openai-oauth-copilot-chat-<version>.vsix --force
-```
-
-## Release workflow
-
-User-visible pull requests normally include a Changeset:
+Add a Changeset for user-visible work:
 
 ```bash
 npm run changeset
 ```
 
-Changesets maintains a version pull request on `main`. Merging that pull request publishes the VSIX to the Visual Studio Marketplace and attaches the same artifact to a GitHub release. The release workflow skips an existing version tag, preventing duplicate publication.
+Merging to `main` updates or creates a version pull request. After the version
+pull request merges, release automation validates the project, publishes the
+VSIX to the Marketplace, and creates a GitHub release.
 
-The packaged extension contains compiled runtime files, Marketplace metadata, the changelog, license, README, and icon. Source, tests, maps, repository automation, project documentation, and local build artifacts are excluded by `.vscodeignore`.
+The packaged extension contains compiled runtime files, Marketplace metadata,
+the changelog, license, README, and icon. Source, tests, maps, repository
+automation, project documentation, and local build artifacts are excluded by
+`.vscodeignore`. The checked-in Codex client version is updated manually from
+the official Codex releases API via `npm run update-codex-version`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,6 @@
 # Security
 
-## Credential handling
+## Credential storage
 
 - OAuth access and refresh tokens are stored with VS Code Secret Storage.
 - Tokens and prompts are never written to the output channel.
@@ -16,6 +16,14 @@
 - `https://models.dev/api.json` for public model metadata enrichment only
 
 Requests use the independent originator `openai-oauth-copilot-chat` and a matching user agent. They do not identify as the official Codex CLI or OpenAI VS Code extension.
+
+## Inline completions
+
+When `openaiOAuth.inlineSuggestions` is enabled, each suggestion sends a bounded window of the current document (a fixed number of lines before the cursor and a bounded suffix after it) to ChatGPT's Codex responses endpoint. Upstream error bodies are never surfaced or logged because they can echo prompt context, and suggestion text flows only into the editor's ghost text. The feature is disabled by default.
+
+## Logging
+
+The output channel records only status and metadata. It does not record OAuth tokens, prompts, response text, or account data.
 
 ## Reporting vulnerabilities
 


### PR DESCRIPTION
Standardizes docs/security.md and docs/development.md across all grikomsn extensions. No Changeset needed (docs-only change).

**Security**: standardized title to `# Security`, section names to `## Credential storage` / `## Network destinations` / `## Inline completions` / `## Logging` / `## Reporting vulnerabilities`.

**Development**: standardized to Prerequisites → Validate → Architecture → Extension Development Host → Release structure.
